### PR TITLE
feat: implement ELink API support for related article discovery (#4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,10 @@ pub use pmc::{
     MarkdownConfig, PmcClient, PmcFullText, PmcMarkdownConverter, PmcXmlParser, Reference,
     ReferenceStyle, Table,
 };
-pub use pubmed::{DatabaseInfo, FieldInfo, LinkInfo, PubMedArticle, PubMedClient};
+pub use pubmed::{
+    Citations, DatabaseInfo, FieldInfo, LinkInfo, PmcLinks, PubMedArticle, PubMedClient,
+    RelatedArticles,
+};
 pub use query::{ArticleType, Language, SearchQuery};
 pub use rate_limit::RateLimiter;
 
@@ -298,6 +301,87 @@ impl Client {
     /// ```
     pub async fn get_database_info(&self, database: &str) -> Result<DatabaseInfo> {
         self.pubmed.get_database_info(database).await
+    }
+
+    /// Get related articles for given PMIDs
+    ///
+    /// # Arguments
+    ///
+    /// * `pmids` - List of PubMed IDs to find related articles for
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result<RelatedArticles>` containing related article information
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use pubmed_client_rs::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new();
+    ///     let related = client.get_related_articles(&[31978945]).await?;
+    ///     println!("Found {} related articles", related.related_pmids.len());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn get_related_articles(&self, pmids: &[u32]) -> Result<RelatedArticles> {
+        self.pubmed.get_related_articles(pmids).await
+    }
+
+    /// Get PMC links for given PMIDs (full-text availability)
+    ///
+    /// # Arguments
+    ///
+    /// * `pmids` - List of PubMed IDs to check for PMC availability
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result<PmcLinks>` containing PMC IDs with full text available
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use pubmed_client_rs::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new();
+    ///     let pmc_links = client.get_pmc_links(&[31978945]).await?;
+    ///     println!("Found {} PMC articles", pmc_links.pmc_ids.len());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn get_pmc_links(&self, pmids: &[u32]) -> Result<PmcLinks> {
+        self.pubmed.get_pmc_links(pmids).await
+    }
+
+    /// Get citing articles for given PMIDs
+    ///
+    /// # Arguments
+    ///
+    /// * `pmids` - List of PubMed IDs to find citing articles for
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result<Citations>` containing citing article information
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use pubmed_client_rs::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new();
+    ///     let citations = client.get_citations(&[31978945]).await?;
+    ///     println!("Found {} citing articles", citations.citing_pmids.len());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn get_citations(&self, pmids: &[u32]) -> Result<Citations> {
+        self.pubmed.get_citations(pmids).await
     }
 }
 

--- a/src/pubmed/client.rs
+++ b/src/pubmed/client.rs
@@ -1,8 +1,10 @@
 use crate::config::ClientConfig;
 use crate::error::{PubMedError, Result};
-use crate::pubmed::models::{DatabaseInfo, FieldInfo, LinkInfo, PubMedArticle};
+use crate::pubmed::models::{
+    Citations, DatabaseInfo, FieldInfo, LinkInfo, PmcLinks, PubMedArticle, RelatedArticles,
+};
 use crate::pubmed::parser::PubMedXmlParser;
-use crate::pubmed::responses::{EInfoResponse, ESearchResult};
+use crate::pubmed::responses::{EInfoResponse, ELinkResponse, ESearchResult};
 use crate::rate_limit::RateLimiter;
 use reqwest::Client;
 use tracing::{debug, info, instrument, warn};
@@ -576,6 +578,263 @@ impl PubMedClient {
         );
 
         Ok(database_info)
+    }
+
+    /// Get related articles for given PMIDs
+    ///
+    /// # Arguments
+    ///
+    /// * `pmids` - List of PubMed IDs to find related articles for
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result<RelatedArticles>` containing related article information
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use pubmed_client_rs::PubMedClient;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = PubMedClient::new();
+    ///     let related = client.get_related_articles(&[31978945]).await?;
+    ///     println!("Found {} related articles", related.related_pmids.len());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[instrument(skip(self), fields(pmids_count = pmids.len()))]
+    pub async fn get_related_articles(&self, pmids: &[u32]) -> Result<RelatedArticles> {
+        if pmids.is_empty() {
+            return Ok(RelatedArticles {
+                source_pmids: Vec::new(),
+                related_pmids: Vec::new(),
+                link_type: "pubmed_pubmed".to_string(),
+            });
+        }
+
+        let elink_response = self.elink_request(pmids, "pubmed", "pubmed_pubmed").await?;
+
+        let mut all_related_pmids = Vec::new();
+
+        for linkset in elink_response.linksets {
+            if let Some(linkset_dbs) = linkset.linkset_dbs {
+                for linkset_db in linkset_dbs {
+                    if linkset_db.link_name == "pubmed_pubmed" {
+                        for link_id in linkset_db.links {
+                            if let Ok(pmid) = link_id.parse::<u32>() {
+                                all_related_pmids.push(pmid);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Remove duplicates and original PMIDs
+        all_related_pmids.sort_unstable();
+        all_related_pmids.dedup();
+        all_related_pmids.retain(|&pmid| !pmids.contains(&pmid));
+
+        info!(
+            source_count = pmids.len(),
+            related_count = all_related_pmids.len(),
+            "Related articles retrieved successfully"
+        );
+
+        Ok(RelatedArticles {
+            source_pmids: pmids.to_vec(),
+            related_pmids: all_related_pmids,
+            link_type: "pubmed_pubmed".to_string(),
+        })
+    }
+
+    /// Get PMC links for given PMIDs (full-text availability)
+    ///
+    /// # Arguments
+    ///
+    /// * `pmids` - List of PubMed IDs to check for PMC availability
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result<PmcLinks>` containing PMC IDs with full text available
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use pubmed_client_rs::PubMedClient;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = PubMedClient::new();
+    ///     let pmc_links = client.get_pmc_links(&[31978945]).await?;
+    ///     println!("Found {} PMC articles", pmc_links.pmc_ids.len());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[instrument(skip(self), fields(pmids_count = pmids.len()))]
+    pub async fn get_pmc_links(&self, pmids: &[u32]) -> Result<PmcLinks> {
+        if pmids.is_empty() {
+            return Ok(PmcLinks {
+                source_pmids: Vec::new(),
+                pmc_ids: Vec::new(),
+            });
+        }
+
+        let elink_response = self.elink_request(pmids, "pmc", "pubmed_pmc").await?;
+
+        let mut pmc_ids = Vec::new();
+
+        for linkset in elink_response.linksets {
+            if let Some(linkset_dbs) = linkset.linkset_dbs {
+                for linkset_db in linkset_dbs {
+                    if linkset_db.link_name == "pubmed_pmc" && linkset_db.db_to == "pmc" {
+                        pmc_ids.extend(linkset_db.links);
+                    }
+                }
+            }
+        }
+
+        // Remove duplicates
+        pmc_ids.sort();
+        pmc_ids.dedup();
+
+        info!(
+            source_count = pmids.len(),
+            pmc_count = pmc_ids.len(),
+            "PMC links retrieved successfully"
+        );
+
+        Ok(PmcLinks {
+            source_pmids: pmids.to_vec(),
+            pmc_ids,
+        })
+    }
+
+    /// Get citing articles for given PMIDs
+    ///
+    /// # Arguments
+    ///
+    /// * `pmids` - List of PubMed IDs to find citing articles for
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result<Citations>` containing citing article information
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use pubmed_client_rs::PubMedClient;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = PubMedClient::new();
+    ///     let citations = client.get_citations(&[31978945]).await?;
+    ///     println!("Found {} citing articles", citations.citing_pmids.len());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[instrument(skip(self), fields(pmids_count = pmids.len()))]
+    pub async fn get_citations(&self, pmids: &[u32]) -> Result<Citations> {
+        if pmids.is_empty() {
+            return Ok(Citations {
+                source_pmids: Vec::new(),
+                citing_pmids: Vec::new(),
+                link_type: "pubmed_pubmed_citedin".to_string(),
+            });
+        }
+
+        let elink_response = self
+            .elink_request(pmids, "pubmed", "pubmed_pubmed_citedin")
+            .await?;
+
+        let mut citing_pmids = Vec::new();
+
+        for linkset in elink_response.linksets {
+            if let Some(linkset_dbs) = linkset.linkset_dbs {
+                for linkset_db in linkset_dbs {
+                    if linkset_db.link_name == "pubmed_pubmed_citedin" {
+                        for link_id in linkset_db.links {
+                            if let Ok(pmid) = link_id.parse::<u32>() {
+                                citing_pmids.push(pmid);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Remove duplicates
+        citing_pmids.sort_unstable();
+        citing_pmids.dedup();
+
+        info!(
+            source_count = pmids.len(),
+            citing_count = citing_pmids.len(),
+            "Citations retrieved successfully"
+        );
+
+        Ok(Citations {
+            source_pmids: pmids.to_vec(),
+            citing_pmids,
+            link_type: "pubmed_pubmed_citedin".to_string(),
+        })
+    }
+
+    /// Internal helper method for ELink API requests
+    async fn elink_request(
+        &self,
+        pmids: &[u32],
+        target_db: &str,
+        link_name: &str,
+    ) -> Result<ELinkResponse> {
+        // Convert PMIDs to strings and join with commas
+        let id_list: Vec<String> = pmids.iter().map(|id| id.to_string()).collect();
+        let ids = id_list.join(",");
+
+        // Acquire rate limit token before making request
+        self.rate_limiter.acquire().await?;
+
+        // Build URL with API parameters
+        let mut url = format!(
+            "{}/elink.fcgi?dbfrom=pubmed&db={}&id={}&linkname={}&retmode=json",
+            self.base_url,
+            urlencoding::encode(target_db),
+            urlencoding::encode(&ids),
+            urlencoding::encode(link_name)
+        );
+
+        // Add API parameters (API key, email, tool)
+        let api_params = self.config.build_api_params();
+        for (key, value) in api_params {
+            url.push('&');
+            url.push_str(&key);
+            url.push('=');
+            url.push_str(&urlencoding::encode(&value));
+        }
+
+        debug!("Making ELink API request");
+        let response = self.client.get(&url).send().await?;
+
+        if !response.status().is_success() {
+            warn!(
+                "ELink API request failed with status: {}",
+                response.status()
+            );
+            return Err(PubMedError::ApiError {
+                message: format!(
+                    "HTTP {}: {}",
+                    response.status(),
+                    response
+                        .status()
+                        .canonical_reason()
+                        .unwrap_or("Unknown error")
+                ),
+            });
+        }
+
+        let elink_response: ELinkResponse = response.json().await?;
+        Ok(elink_response)
     }
 }
 

--- a/src/pubmed/mod.rs
+++ b/src/pubmed/mod.rs
@@ -10,5 +10,7 @@ pub mod responses;
 
 // Re-export public types
 pub use client::PubMedClient;
-pub use models::{DatabaseInfo, FieldInfo, LinkInfo, PubMedArticle};
+pub use models::{
+    Citations, DatabaseInfo, FieldInfo, LinkInfo, PmcLinks, PubMedArticle, RelatedArticles,
+};
 pub use parser::PubMedXmlParser;

--- a/src/pubmed/models.rs
+++ b/src/pubmed/models.rs
@@ -77,3 +77,34 @@ pub struct LinkInfo {
     /// Target database
     pub target_db: String,
 }
+
+/// Results from ELink API for related article discovery
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RelatedArticles {
+    /// Source PMIDs that were queried
+    pub source_pmids: Vec<u32>,
+    /// Related article PMIDs found
+    pub related_pmids: Vec<u32>,
+    /// Link type (e.g., "pubmed_pubmed", "pubmed_pubmed_reviews")
+    pub link_type: String,
+}
+
+/// PMC links discovered through ELink API
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PmcLinks {
+    /// Source PMIDs that were queried
+    pub source_pmids: Vec<u32>,
+    /// PMC IDs that have full text available
+    pub pmc_ids: Vec<String>,
+}
+
+/// Citation information from ELink API
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Citations {
+    /// Source PMIDs that were queried
+    pub source_pmids: Vec<u32>,
+    /// PMIDs of articles that cite the source articles
+    pub citing_pmids: Vec<u32>,
+    /// Link type (e.g., "pubmed_pubmed_citedin")
+    pub link_type: String,
+}

--- a/src/pubmed/responses.rs
+++ b/src/pubmed/responses.rs
@@ -104,3 +104,30 @@ pub(crate) struct EInfoLink {
     #[serde(rename = "dbto")]
     pub db_to: String,
 }
+
+// ELink API response structures
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ELinkResponse {
+    #[serde(rename = "linksets")]
+    pub linksets: Vec<ELinkSet>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ELinkSet {
+    #[serde(rename = "dbfrom")]
+    pub db_from: String,
+    #[serde(rename = "ids")]
+    pub ids: Vec<String>,
+    #[serde(rename = "linksetdbs", default)]
+    pub linkset_dbs: Option<Vec<ELinkSetDb>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ELinkSetDb {
+    #[serde(rename = "dbto")]
+    pub db_to: String,
+    #[serde(rename = "linkname")]
+    pub link_name: String,
+    #[serde(rename = "links")]
+    pub links: Vec<String>,
+}

--- a/tests/test_elink_integration.rs
+++ b/tests/test_elink_integration.rs
@@ -1,0 +1,212 @@
+use pubmed_client_rs::{Client, PubMedClient};
+
+#[tokio::test]
+async fn test_get_related_articles_integration() {
+    let client = PubMedClient::new();
+
+    // Use a well-known PMID that should have related articles
+    let test_pmids = vec![31978945];
+
+    match client.get_related_articles(&test_pmids).await {
+        Ok(related) => {
+            assert_eq!(related.source_pmids, test_pmids);
+            assert_eq!(related.link_type, "pubmed_pubmed");
+            println!(
+                "Found {} related articles for PMID {}",
+                related.related_pmids.len(),
+                test_pmids[0]
+            );
+
+            // Related PMIDs should not contain the original PMID
+            for &pmid in &related.related_pmids {
+                assert!(
+                    !test_pmids.contains(&pmid),
+                    "Related articles should not include source PMID"
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("Warning: Could not fetch related articles: {}", e);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_pmc_links_integration() {
+    let client = PubMedClient::new();
+
+    // Use PMIDs that are likely to have PMC full text
+    let test_pmids = vec![31978945, 33515491];
+
+    match client.get_pmc_links(&test_pmids).await {
+        Ok(pmc_links) => {
+            assert_eq!(pmc_links.source_pmids, test_pmids);
+            println!(
+                "Found {} PMC articles for {} PMIDs",
+                pmc_links.pmc_ids.len(),
+                test_pmids.len()
+            );
+
+            // Print PMC IDs if found
+            if !pmc_links.pmc_ids.is_empty() {
+                println!(
+                    "PMC IDs: {:?}",
+                    &pmc_links.pmc_ids[..5.min(pmc_links.pmc_ids.len())]
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("Warning: Could not fetch PMC links: {}", e);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_citations_integration() {
+    let client = PubMedClient::new();
+
+    // Use a well-known PMID that should have citing articles
+    let test_pmids = vec![31978945];
+
+    match client.get_citations(&test_pmids).await {
+        Ok(citations) => {
+            assert_eq!(citations.source_pmids, test_pmids);
+            assert_eq!(citations.link_type, "pubmed_pubmed_citedin");
+            println!(
+                "Found {} citing articles for PMID {}",
+                citations.citing_pmids.len(),
+                test_pmids[0]
+            );
+        }
+        Err(e) => {
+            eprintln!("Warning: Could not fetch citations: {}", e);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_empty_pmids_handling() {
+    let client = PubMedClient::new();
+
+    // Test empty input handling
+    let empty_pmids: Vec<u32> = vec![];
+
+    let related = client.get_related_articles(&empty_pmids).await.unwrap();
+    assert!(related.source_pmids.is_empty());
+    assert!(related.related_pmids.is_empty());
+    assert_eq!(related.link_type, "pubmed_pubmed");
+
+    let pmc_links = client.get_pmc_links(&empty_pmids).await.unwrap();
+    assert!(pmc_links.source_pmids.is_empty());
+    assert!(pmc_links.pmc_ids.is_empty());
+
+    let citations = client.get_citations(&empty_pmids).await.unwrap();
+    assert!(citations.source_pmids.is_empty());
+    assert!(citations.citing_pmids.is_empty());
+    assert_eq!(citations.link_type, "pubmed_pubmed_citedin");
+}
+
+#[tokio::test]
+async fn test_elink_methods_through_combined_client() {
+    let client = Client::new();
+
+    let test_pmids = vec![31978945];
+
+    // Test related articles through combined client
+    match client.get_related_articles(&test_pmids).await {
+        Ok(related) => {
+            println!(
+                "Combined client: Found {} related articles",
+                related.related_pmids.len()
+            );
+        }
+        Err(e) => {
+            eprintln!("Warning: Combined client related articles failed: {}", e);
+        }
+    }
+
+    // Test PMC links through combined client
+    match client.get_pmc_links(&test_pmids).await {
+        Ok(pmc_links) => {
+            println!(
+                "Combined client: Found {} PMC links",
+                pmc_links.pmc_ids.len()
+            );
+        }
+        Err(e) => {
+            eprintln!("Warning: Combined client PMC links failed: {}", e);
+        }
+    }
+
+    // Test citations through combined client
+    match client.get_citations(&test_pmids).await {
+        Ok(citations) => {
+            println!(
+                "Combined client: Found {} citations",
+                citations.citing_pmids.len()
+            );
+        }
+        Err(e) => {
+            eprintln!("Warning: Combined client citations failed: {}", e);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_multiple_pmids_handling() {
+    let client = PubMedClient::new();
+
+    // Test with multiple PMIDs
+    let multiple_pmids = vec![31978945, 33515491, 32960547];
+
+    match client.get_related_articles(&multiple_pmids).await {
+        Ok(related) => {
+            assert_eq!(related.source_pmids, multiple_pmids);
+            println!(
+                "Multiple PMIDs: Found {} related articles for {} source PMIDs",
+                related.related_pmids.len(),
+                multiple_pmids.len()
+            );
+
+            // Ensure no source PMIDs are in the related results
+            for &source_pmid in &multiple_pmids {
+                assert!(
+                    !related.related_pmids.contains(&source_pmid),
+                    "Related articles should not contain source PMIDs"
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("Warning: Multiple PMIDs related articles failed: {}", e);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_elink_deduplication() {
+    let client = PubMedClient::new();
+
+    // Test with duplicate PMIDs to ensure deduplication works
+    let duplicate_pmids = vec![31978945, 31978945, 31978945];
+
+    match client.get_related_articles(&duplicate_pmids).await {
+        Ok(related) => {
+            // Source PMIDs should still contain duplicates (as provided)
+            assert_eq!(related.source_pmids, duplicate_pmids);
+
+            // Related PMIDs should be deduplicated
+            let mut sorted_related = related.related_pmids.clone();
+            sorted_related.sort_unstable();
+            let original_len = sorted_related.len();
+            sorted_related.dedup();
+            assert_eq!(
+                original_len,
+                sorted_related.len(),
+                "Related PMIDs should already be deduplicated"
+            );
+        }
+        Err(e) => {
+            eprintln!("Warning: Duplicate PMIDs test failed: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- ✅ Implement complete ELink API support for discovering related articles, citations, and cross-database links
- ✅ Add three new methods to PubMedClient and main Client API
- ✅ Comprehensive data models and error handling
- ✅ Full integration test suite with edge case coverage

## Features Implemented

### 🔗 ELink API Methods
- `get_related_articles()` - Discover related articles using `pubmed_pubmed` linkname
- `get_pmc_links()` - Check PMC full-text availability using `pubmed_pmc` linkname
- `get_citations()` - Find citing articles using `pubmed_pubmed_citedin` linkname

### 📊 Data Models
- `RelatedArticles` - Results from related article discovery with source/related PMIDs
- `PmcLinks` - PMC full-text availability with source PMIDs and PMC IDs
- `Citations` - Citation information with source PMIDs and citing PMIDs

### 🎯 Technical Implementation
- **Rate Limiting**: Integrated with existing token bucket system
- **JSON Parsing**: Proper ELink API response handling with serde
- **Deduplication**: Automatic removal of duplicates and source PMIDs from results
- **Error Handling**: Comprehensive error handling with tracing integration
- **Validation**: Empty input validation and edge case handling

### 🔧 API Integration
- Added all ELink methods to main `Client` struct for unified access
- Exported new types in public API (`Citations`, `PmcLinks`, `RelatedArticles`)
- Comprehensive documentation with usage examples for all methods

## Test Coverage

- ✅ Integration tests for all three ELink methods
- ✅ Empty PMIDs handling verification
- ✅ Multiple PMIDs processing with deduplication
- ✅ Combined client API testing
- ✅ Error handling and edge case coverage
- ✅ Source PMID filtering validation

## Files Changed

| File | Purpose |
|------|---------|
| `src/pubmed/client.rs` | Core ELink methods implementation |
| `src/pubmed/models.rs` | Public API data structures |
| `src/pubmed/responses.rs` | Internal JSON response parsing |
| `src/pubmed/mod.rs` | Module exports |
| `src/lib.rs` | Main Client integration |
| `tests/test_elink_integration.rs` | Comprehensive test suite |

## Usage Examples

### Related Articles Discovery
```rust
let client = Client::new();
let related = client.get_related_articles(&[31978945]).await?;
println\!("Found {} related articles", related.related_pmids.len());
```

### PMC Full-Text Availability
```rust
let pmc_links = client.get_pmc_links(&[31978945, 33515491]).await?;
println\!("Found {} PMC articles", pmc_links.pmc_ids.len());
```

### Citation Discovery
```rust
let citations = client.get_citations(&[31978945]).await?;
println\!("Found {} citing articles", citations.citing_pmids.len());
```

## Testing

All tests pass successfully:
```bash
cargo test --test test_elink_integration
# 7 tests passed, including integration and edge cases
```

Resolves #4

🤖 Generated with [Claude Code](https://claude.ai/code)