### PR TITLE
feat: Add MeSH term extraction and search capabilities

### DIFF
--- a/.claude/commands/resolve.md
+++ b/.claude/commands/resolve.md
@@ -1,0 +1,3 @@
+Resolve issue $ARGUMENT.
+
+First, checkout to main branch, pull origin, and create a new branch for the issue.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,6 @@ pub mod config;
 pub mod error;
 pub mod pmc;
 pub mod pubmed;
-pub mod query;
 pub mod rate_limit;
 
 // Re-export main types for convenience
@@ -112,10 +111,9 @@ pub use pmc::{
     ReferenceStyle, Table,
 };
 pub use pubmed::{
-    Citations, DatabaseInfo, FieldInfo, LinkInfo, PmcLinks, PubMedArticle, PubMedClient,
-    RelatedArticles,
+    ArticleType, Citations, DatabaseInfo, FieldInfo, Language, LinkInfo, PmcLinks, PubMedArticle,
+    PubMedClient, RelatedArticles, SearchQuery,
 };
-pub use query::{ArticleType, Language, SearchQuery};
 pub use rate_limit::RateLimiter;
 
 /// Convenience client that combines both PubMed and PMC functionality

--- a/src/pubmed/client.rs
+++ b/src/pubmed/client.rs
@@ -42,8 +42,8 @@ impl PubMedClient {
     ///     Ok(())
     /// }
     /// ```
-    pub fn search(&self) -> crate::query::SearchQuery {
-        crate::query::SearchQuery::new()
+    pub fn search(&self) -> super::query::SearchQuery {
+        super::query::SearchQuery::new()
     }
 
     /// Create a new PubMed client with default configuration

--- a/src/pubmed/mod.rs
+++ b/src/pubmed/mod.rs
@@ -6,11 +6,14 @@
 pub mod client;
 pub mod models;
 pub mod parser;
+pub mod query;
 pub mod responses;
 
 // Re-export public types
 pub use client::PubMedClient;
 pub use models::{
-    Citations, DatabaseInfo, FieldInfo, LinkInfo, PmcLinks, PubMedArticle, RelatedArticles,
+    ChemicalConcept, Citations, DatabaseInfo, FieldInfo, LinkInfo, MeshHeading, MeshQualifier,
+    MeshTerm, PmcLinks, PubMedArticle, RelatedArticles, SupplementalConcept,
 };
 pub use parser::PubMedXmlParser;
+pub use query::{ArticleType, Language, SearchQuery};

--- a/src/pubmed/models.rs
+++ b/src/pubmed/models.rs
@@ -19,6 +19,12 @@ pub struct PubMedArticle {
     pub abstract_text: Option<String>,
     /// Article types (e.g., "Clinical Trial", "Review", etc.)
     pub article_types: Vec<String>,
+    /// MeSH headings associated with the article
+    pub mesh_headings: Option<Vec<MeshHeading>>,
+    /// Author-provided keywords
+    pub keywords: Option<Vec<String>>,
+    /// Chemical substances mentioned in the article
+    pub chemical_list: Option<Vec<ChemicalConcept>>,
 }
 
 /// Database information from EInfo API
@@ -107,4 +113,273 @@ pub struct Citations {
     pub citing_pmids: Vec<u32>,
     /// Link type (e.g., "pubmed_pubmed_citedin")
     pub link_type: String,
+}
+
+/// Medical Subject Heading (MeSH) qualifier/subheading
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MeshQualifier {
+    /// Qualifier name (e.g., "drug therapy", "genetics")
+    pub qualifier_name: String,
+    /// Unique identifier for the qualifier
+    pub qualifier_ui: String,
+    /// Whether this qualifier is a major topic
+    pub major_topic: bool,
+}
+
+/// Medical Subject Heading (MeSH) descriptor term
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MeshTerm {
+    /// Descriptor name (e.g., "Diabetes Mellitus, Type 2")
+    pub descriptor_name: String,
+    /// Unique identifier for the descriptor
+    pub descriptor_ui: String,
+    /// Whether this term is a major topic of the article
+    pub major_topic: bool,
+    /// Associated qualifiers/subheadings
+    pub qualifiers: Vec<MeshQualifier>,
+}
+
+/// Supplemental MeSH concept (for substances, diseases, etc.)
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SupplementalConcept {
+    /// Concept name
+    pub name: String,
+    /// Unique identifier
+    pub ui: String,
+    /// Concept type (e.g., "Disease", "Drug")
+    pub concept_type: Option<String>,
+}
+
+/// Chemical substance mentioned in the article
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChemicalConcept {
+    /// Chemical name
+    pub name: String,
+    /// Registry number (e.g., CAS number)
+    pub registry_number: Option<String>,
+    /// Chemical UI
+    pub ui: Option<String>,
+}
+
+/// Complete MeSH heading information for an article
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MeshHeading {
+    /// MeSH descriptor terms
+    pub mesh_terms: Vec<MeshTerm>,
+    /// Supplemental concepts
+    pub supplemental_concepts: Vec<SupplementalConcept>,
+}
+
+impl PubMedArticle {
+    /// Get all major MeSH terms from the article
+    ///
+    /// # Returns
+    ///
+    /// A vector of major MeSH term names
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use pubmed_client_rs::pubmed::PubMedArticle;
+    /// # let article = PubMedArticle {
+    /// #     pmid: "123".to_string(),
+    /// #     title: "Test".to_string(),
+    /// #     authors: vec![],
+    /// #     journal: "Test Journal".to_string(),
+    /// #     pub_date: "2023".to_string(),
+    /// #     doi: None,
+    /// #     abstract_text: None,
+    /// #     article_types: vec![],
+    /// #     mesh_headings: None,
+    /// #     keywords: None,
+    /// #     chemical_list: None,
+    /// # };
+    /// let major_terms = article.get_major_mesh_terms();
+    /// ```
+    pub fn get_major_mesh_terms(&self) -> Vec<String> {
+        let mut major_terms = Vec::new();
+
+        if let Some(mesh_headings) = &self.mesh_headings {
+            for heading in mesh_headings {
+                for term in &heading.mesh_terms {
+                    if term.major_topic {
+                        major_terms.push(term.descriptor_name.clone());
+                    }
+                }
+            }
+        }
+
+        major_terms
+    }
+
+    /// Check if the article has a specific MeSH term
+    ///
+    /// # Arguments
+    ///
+    /// * `term` - The MeSH term to check for
+    ///
+    /// # Returns
+    ///
+    /// `true` if the article has the specified MeSH term, `false` otherwise
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use pubmed_client_rs::pubmed::PubMedArticle;
+    /// # let article = PubMedArticle {
+    /// #     pmid: "123".to_string(),
+    /// #     title: "Test".to_string(),
+    /// #     authors: vec![],
+    /// #     journal: "Test Journal".to_string(),
+    /// #     pub_date: "2023".to_string(),
+    /// #     doi: None,
+    /// #     abstract_text: None,
+    /// #     article_types: vec![],
+    /// #     mesh_headings: None,
+    /// #     keywords: None,
+    /// #     chemical_list: None,
+    /// # };
+    /// let has_diabetes = article.has_mesh_term("Diabetes Mellitus");
+    /// ```
+    pub fn has_mesh_term(&self, term: &str) -> bool {
+        if let Some(mesh_headings) = &self.mesh_headings {
+            for heading in mesh_headings {
+                for mesh_term in &heading.mesh_terms {
+                    if mesh_term.descriptor_name.eq_ignore_ascii_case(term) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Get all MeSH terms from the article
+    ///
+    /// # Returns
+    ///
+    /// A vector of all MeSH term names
+    pub fn get_all_mesh_terms(&self) -> Vec<String> {
+        let mut terms = Vec::new();
+
+        if let Some(mesh_headings) = &self.mesh_headings {
+            for heading in mesh_headings {
+                for term in &heading.mesh_terms {
+                    terms.push(term.descriptor_name.clone());
+                }
+            }
+        }
+
+        terms
+    }
+
+    /// Calculate MeSH term similarity between two articles
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The other article to compare with
+    ///
+    /// # Returns
+    ///
+    /// A similarity score between 0.0 and 1.0 based on Jaccard similarity
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use pubmed_client_rs::pubmed::PubMedArticle;
+    /// # let article1 = PubMedArticle {
+    /// #     pmid: "123".to_string(),
+    /// #     title: "Test".to_string(),
+    /// #     authors: vec![],
+    /// #     journal: "Test Journal".to_string(),
+    /// #     pub_date: "2023".to_string(),
+    /// #     doi: None,
+    /// #     abstract_text: None,
+    /// #     article_types: vec![],
+    /// #     mesh_headings: None,
+    /// #     keywords: None,
+    /// #     chemical_list: None,
+    /// # };
+    /// # let article2 = article1.clone();
+    /// let similarity = article1.mesh_term_similarity(&article2);
+    /// ```
+    pub fn mesh_term_similarity(&self, other: &PubMedArticle) -> f64 {
+        use std::collections::HashSet;
+
+        let terms1: HashSet<String> = self
+            .get_all_mesh_terms()
+            .into_iter()
+            .map(|t| t.to_lowercase())
+            .collect();
+
+        let terms2: HashSet<String> = other
+            .get_all_mesh_terms()
+            .into_iter()
+            .map(|t| t.to_lowercase())
+            .collect();
+
+        if terms1.is_empty() && terms2.is_empty() {
+            return 0.0;
+        }
+
+        let intersection = terms1.intersection(&terms2).count();
+        let union = terms1.union(&terms2).count();
+
+        if union == 0 {
+            0.0
+        } else {
+            intersection as f64 / union as f64
+        }
+    }
+
+    /// Get MeSH qualifiers for a specific term
+    ///
+    /// # Arguments
+    ///
+    /// * `term` - The MeSH term to get qualifiers for
+    ///
+    /// # Returns
+    ///
+    /// A vector of qualifier names for the specified term
+    pub fn get_mesh_qualifiers(&self, term: &str) -> Vec<String> {
+        let mut qualifiers = Vec::new();
+
+        if let Some(mesh_headings) = &self.mesh_headings {
+            for heading in mesh_headings {
+                for mesh_term in &heading.mesh_terms {
+                    if mesh_term.descriptor_name.eq_ignore_ascii_case(term) {
+                        for qualifier in &mesh_term.qualifiers {
+                            qualifiers.push(qualifier.qualifier_name.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        qualifiers
+    }
+
+    /// Check if the article has any MeSH terms
+    ///
+    /// # Returns
+    ///
+    /// `true` if the article has MeSH terms, `false` otherwise
+    pub fn has_mesh_terms(&self) -> bool {
+        self.mesh_headings
+            .as_ref()
+            .map(|h| !h.is_empty())
+            .unwrap_or(false)
+    }
+
+    /// Get chemicals mentioned in the article
+    ///
+    /// # Returns
+    ///
+    /// A vector of chemical names
+    pub fn get_chemical_names(&self) -> Vec<String> {
+        self.chemical_list
+            .as_ref()
+            .map(|chemicals| chemicals.iter().map(|c| c.name.clone()).collect())
+            .unwrap_or_default()
+    }
 }

--- a/tests/test_mesh_functionality.rs
+++ b/tests/test_mesh_functionality.rs
@@ -1,0 +1,470 @@
+use pubmed_client_rs::PubMedClient;
+use pubmed_client_rs::pubmed::{
+    ChemicalConcept, MeshHeading, MeshQualifier, MeshTerm, PubMedArticle, SearchQuery,
+};
+
+#[cfg(test)]
+mod mesh_parsing_tests {
+    use pubmed_client_rs::pubmed::parser::PubMedXmlParser;
+
+    #[test]
+    fn test_mesh_term_parsing() {
+        let xml = r#"<?xml version="1.0" ?>
+<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2023//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_230101.dtd">
+<PubmedArticleSet>
+<PubmedArticle>
+    <MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM">
+        <PMID Version="1">12345678</PMID>
+        <Article>
+            <ArticleTitle>Test Article with MeSH Terms</ArticleTitle>
+            <Abstract>
+                <AbstractText>This is a test abstract.</AbstractText>
+            </Abstract>
+            <AuthorList>
+                <Author>
+                    <LastName>Doe</LastName>
+                    <ForeName>John</ForeName>
+                </Author>
+            </AuthorList>
+            <Journal>
+                <Title>Test Journal</Title>
+            </Journal>
+        </Article>
+        <MeshHeadingList>
+            <MeshHeading>
+                <DescriptorName UI="D003920" MajorTopicYN="Y">Diabetes Mellitus</DescriptorName>
+                <QualifierName UI="Q000188" MajorTopicYN="N">drug therapy</QualifierName>
+            </MeshHeading>
+            <MeshHeading>
+                <DescriptorName UI="D007333" MajorTopicYN="N">Insulin</DescriptorName>
+            </MeshHeading>
+        </MeshHeadingList>
+        <ChemicalList>
+            <Chemical>
+                <RegistryNumber>11061-68-0</RegistryNumber>
+                <NameOfSubstance UI="D007328">Insulin</NameOfSubstance>
+            </Chemical>
+        </ChemicalList>
+        <KeywordList>
+            <Keyword>diabetes treatment</Keyword>
+            <Keyword>insulin therapy</Keyword>
+        </KeywordList>
+        <MedlineJournalInfo>
+            <MedlineTA>Test J</MedlineTA>
+        </MedlineJournalInfo>
+        <PubmedData>
+            <ArticleIdList>
+                <ArticleId IdType="pubmed">12345678</ArticleId>
+            </ArticleIdList>
+            <PublicationStatus>ppublish</PublicationStatus>
+        </PubmedData>
+    </MedlineCitation>
+</PubmedArticle>
+</PubmedArticleSet>"#;
+
+        let article = PubMedXmlParser::parse_article_from_xml(xml, "12345678").unwrap();
+
+        // Test MeSH headings
+        assert!(article.mesh_headings.is_some());
+        let mesh_headings = article.mesh_headings.as_ref().unwrap();
+        assert_eq!(mesh_headings.len(), 2);
+
+        // Test first MeSH heading (major topic with qualifier)
+        let first_heading = &mesh_headings[0];
+        assert_eq!(first_heading.mesh_terms.len(), 1);
+        let diabetes_term = &first_heading.mesh_terms[0];
+        assert_eq!(diabetes_term.descriptor_name, "Diabetes Mellitus");
+        assert_eq!(diabetes_term.descriptor_ui, "D003920");
+        assert!(diabetes_term.major_topic);
+        assert_eq!(diabetes_term.qualifiers.len(), 1);
+        assert_eq!(diabetes_term.qualifiers[0].qualifier_name, "drug therapy");
+        assert_eq!(diabetes_term.qualifiers[0].qualifier_ui, "Q000188");
+        assert!(!diabetes_term.qualifiers[0].major_topic);
+
+        // Test second MeSH heading (non-major topic)
+        let second_heading = &mesh_headings[1];
+        assert_eq!(second_heading.mesh_terms.len(), 1);
+        let insulin_term = &second_heading.mesh_terms[0];
+        assert_eq!(insulin_term.descriptor_name, "Insulin");
+        assert_eq!(insulin_term.descriptor_ui, "D007333");
+        assert!(!insulin_term.major_topic);
+        assert_eq!(insulin_term.qualifiers.len(), 0);
+
+        // Test chemicals
+        assert!(article.chemical_list.is_some());
+        let chemicals = article.chemical_list.as_ref().unwrap();
+        assert_eq!(chemicals.len(), 1);
+        assert_eq!(chemicals[0].name, "Insulin");
+        assert_eq!(chemicals[0].registry_number, Some("11061-68-0".to_string()));
+        assert_eq!(chemicals[0].ui, Some("D007328".to_string()));
+
+        // Test keywords
+        assert!(article.keywords.is_some());
+        let keywords = article.keywords.as_ref().unwrap();
+        assert_eq!(keywords.len(), 2);
+        assert_eq!(keywords[0], "diabetes treatment");
+        assert_eq!(keywords[1], "insulin therapy");
+    }
+
+    #[test]
+    fn test_article_without_mesh_terms() {
+        let xml = r#"<?xml version="1.0" ?>
+<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2023//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_230101.dtd">
+<PubmedArticleSet>
+<PubmedArticle>
+    <MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM">
+        <PMID Version="1">87654321</PMID>
+        <Article>
+            <ArticleTitle>Article Without MeSH Terms</ArticleTitle>
+            <AuthorList>
+                <Author>
+                    <LastName>Smith</LastName>
+                    <ForeName>Jane</ForeName>
+                </Author>
+            </AuthorList>
+            <Journal>
+                <Title>Another Journal</Title>
+            </Journal>
+        </Article>
+        <MedlineJournalInfo>
+            <MedlineTA>Another J</MedlineTA>
+        </MedlineJournalInfo>
+        <PubmedData>
+            <ArticleIdList>
+                <ArticleId IdType="pubmed">87654321</ArticleId>
+            </ArticleIdList>
+            <PublicationStatus>ppublish</PublicationStatus>
+        </PubmedData>
+    </MedlineCitation>
+</PubmedArticle>
+</PubmedArticleSet>"#;
+
+        let article = PubMedXmlParser::parse_article_from_xml(xml, "87654321").unwrap();
+
+        assert!(article.mesh_headings.is_none());
+        assert!(article.chemical_list.is_none());
+        assert!(article.keywords.is_none());
+    }
+}
+
+#[cfg(test)]
+mod mesh_utility_tests {
+    use super::*;
+
+    fn create_test_article_with_mesh() -> PubMedArticle {
+        PubMedArticle {
+            pmid: "12345".to_string(),
+            title: "Test Article".to_string(),
+            authors: vec!["John Doe".to_string()],
+            journal: "Test Journal".to_string(),
+            pub_date: "2023".to_string(),
+            doi: None,
+            abstract_text: None,
+            article_types: vec![],
+            mesh_headings: Some(vec![
+                MeshHeading {
+                    mesh_terms: vec![MeshTerm {
+                        descriptor_name: "Diabetes Mellitus, Type 2".to_string(),
+                        descriptor_ui: "D003924".to_string(),
+                        major_topic: true,
+                        qualifiers: vec![
+                            MeshQualifier {
+                                qualifier_name: "drug therapy".to_string(),
+                                qualifier_ui: "Q000188".to_string(),
+                                major_topic: false,
+                            },
+                            MeshQualifier {
+                                qualifier_name: "genetics".to_string(),
+                                qualifier_ui: "Q000235".to_string(),
+                                major_topic: true,
+                            },
+                        ],
+                    }],
+                    supplemental_concepts: vec![],
+                },
+                MeshHeading {
+                    mesh_terms: vec![MeshTerm {
+                        descriptor_name: "Hypertension".to_string(),
+                        descriptor_ui: "D006973".to_string(),
+                        major_topic: false,
+                        qualifiers: vec![],
+                    }],
+                    supplemental_concepts: vec![],
+                },
+            ]),
+            keywords: Some(vec!["diabetes".to_string(), "treatment".to_string()]),
+            chemical_list: Some(vec![ChemicalConcept {
+                name: "Metformin".to_string(),
+                registry_number: Some("657-24-9".to_string()),
+                ui: Some("D008687".to_string()),
+            }]),
+        }
+    }
+
+    #[test]
+    fn test_get_major_mesh_terms() {
+        let article = create_test_article_with_mesh();
+        let major_terms = article.get_major_mesh_terms();
+
+        assert_eq!(major_terms.len(), 1);
+        assert_eq!(major_terms[0], "Diabetes Mellitus, Type 2");
+    }
+
+    #[test]
+    fn test_has_mesh_term() {
+        let article = create_test_article_with_mesh();
+
+        assert!(article.has_mesh_term("Diabetes Mellitus, Type 2"));
+        assert!(article.has_mesh_term("DIABETES MELLITUS, TYPE 2")); // Case insensitive
+        assert!(article.has_mesh_term("Hypertension"));
+        assert!(!article.has_mesh_term("Cancer"));
+    }
+
+    #[test]
+    fn test_get_all_mesh_terms() {
+        let article = create_test_article_with_mesh();
+        let all_terms = article.get_all_mesh_terms();
+
+        assert_eq!(all_terms.len(), 2);
+        assert!(all_terms.contains(&"Diabetes Mellitus, Type 2".to_string()));
+        assert!(all_terms.contains(&"Hypertension".to_string()));
+    }
+
+    #[test]
+    fn test_mesh_term_similarity() {
+        let article1 = create_test_article_with_mesh();
+        let mut article2 = create_test_article_with_mesh();
+
+        // Same article should have similarity of 1.0
+        let similarity = article1.mesh_term_similarity(&article2);
+        assert_eq!(similarity, 1.0);
+
+        // Different MeSH terms
+        article2.mesh_headings = Some(vec![MeshHeading {
+            mesh_terms: vec![
+                MeshTerm {
+                    descriptor_name: "Diabetes Mellitus, Type 2".to_string(),
+                    descriptor_ui: "D003924".to_string(),
+                    major_topic: true,
+                    qualifiers: vec![],
+                },
+                MeshTerm {
+                    descriptor_name: "Obesity".to_string(),
+                    descriptor_ui: "D009765".to_string(),
+                    major_topic: false,
+                    qualifiers: vec![],
+                },
+            ],
+            supplemental_concepts: vec![],
+        }]);
+
+        let similarity = article1.mesh_term_similarity(&article2);
+        // Should have partial similarity (1 common term out of 3 unique terms)
+        assert!(similarity > 0.0 && similarity < 1.0);
+        assert_eq!(similarity, 1.0 / 3.0); // Jaccard similarity
+
+        // No MeSH terms
+        let article3 = PubMedArticle {
+            pmid: "54321".to_string(),
+            title: "Test".to_string(),
+            authors: vec![],
+            journal: "Test".to_string(),
+            pub_date: "2023".to_string(),
+            doi: None,
+            abstract_text: None,
+            article_types: vec![],
+            mesh_headings: None,
+            keywords: None,
+            chemical_list: None,
+        };
+
+        assert_eq!(article1.mesh_term_similarity(&article3), 0.0);
+    }
+
+    #[test]
+    fn test_get_mesh_qualifiers() {
+        let article = create_test_article_with_mesh();
+
+        let qualifiers = article.get_mesh_qualifiers("Diabetes Mellitus, Type 2");
+        assert_eq!(qualifiers.len(), 2);
+        assert!(qualifiers.contains(&"drug therapy".to_string()));
+        assert!(qualifiers.contains(&"genetics".to_string()));
+
+        let qualifiers = article.get_mesh_qualifiers("Hypertension");
+        assert_eq!(qualifiers.len(), 0);
+
+        let qualifiers = article.get_mesh_qualifiers("Nonexistent Term");
+        assert_eq!(qualifiers.len(), 0);
+    }
+
+    #[test]
+    fn test_has_mesh_terms() {
+        let article = create_test_article_with_mesh();
+        assert!(article.has_mesh_terms());
+
+        let mut article_no_mesh = article.clone();
+        article_no_mesh.mesh_headings = None;
+        assert!(!article_no_mesh.has_mesh_terms());
+
+        let mut article_empty_mesh = article.clone();
+        article_empty_mesh.mesh_headings = Some(vec![]);
+        assert!(!article_empty_mesh.has_mesh_terms());
+    }
+
+    #[test]
+    fn test_get_chemical_names() {
+        let article = create_test_article_with_mesh();
+        let chemicals = article.get_chemical_names();
+
+        assert_eq!(chemicals.len(), 1);
+        assert_eq!(chemicals[0], "Metformin");
+
+        let mut article_no_chemicals = article.clone();
+        article_no_chemicals.chemical_list = None;
+        let chemicals = article_no_chemicals.get_chemical_names();
+        assert_eq!(chemicals.len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod mesh_search_tests {
+    use super::*;
+
+    #[test]
+    fn test_mesh_major_topic_query() {
+        let query = SearchQuery::new()
+            .mesh_major_topic("Diabetes Mellitus, Type 2")
+            .build();
+
+        assert_eq!(query, "Diabetes Mellitus, Type 2[MeSH Major Topic]");
+    }
+
+    #[test]
+    fn test_mesh_term_query() {
+        let query = SearchQuery::new().mesh_term("Neoplasms").build();
+
+        assert_eq!(query, "Neoplasms[MeSH Terms]");
+    }
+
+    #[test]
+    fn test_multiple_mesh_terms_query() {
+        let query = SearchQuery::new()
+            .mesh_terms(&["Neoplasms", "Antineoplastic Agents"])
+            .build();
+
+        assert_eq!(
+            query,
+            "Neoplasms[MeSH Terms] AND Antineoplastic Agents[MeSH Terms]"
+        );
+    }
+
+    #[test]
+    fn test_mesh_subheading_query() {
+        let query = SearchQuery::new()
+            .mesh_term("Diabetes Mellitus")
+            .mesh_subheading("drug therapy")
+            .build();
+
+        assert_eq!(
+            query,
+            "Diabetes Mellitus[MeSH Terms] AND drug therapy[MeSH Subheading]"
+        );
+    }
+
+    #[test]
+    fn test_complex_mesh_query() {
+        let query = SearchQuery::new()
+            .query("clinical outcomes")
+            .mesh_major_topic("Diabetes Mellitus, Type 2")
+            .mesh_subheading("drug therapy")
+            .published_after(2020)
+            .clinical_trials_only()
+            .build();
+
+        let expected = "clinical outcomes AND Diabetes Mellitus, Type 2[MeSH Major Topic] AND drug therapy[MeSH Subheading] AND 2020:3000[pdat] AND Clinical Trial[pt]";
+        assert_eq!(query, expected);
+    }
+
+    #[test]
+    fn test_mesh_query_with_free_text() {
+        let query = SearchQuery::new()
+            .query("machine learning")
+            .mesh_terms(&["Artificial Intelligence", "Machine Learning"])
+            .free_full_text()
+            .build();
+
+        let expected = "machine learning AND Artificial Intelligence[MeSH Terms] AND Machine Learning[MeSH Terms] AND free full text[sb]";
+        assert_eq!(query, expected);
+    }
+}
+
+#[tokio::test]
+#[ignore] // This is an integration test that requires network access
+async fn test_mesh_search_integration() {
+    use pubmed_client_rs::ClientConfig;
+
+    // Create client with rate limiting for testing
+    let config = ClientConfig::new().with_rate_limit(1.0);
+    let client = PubMedClient::with_config(config);
+
+    // Search for articles with specific MeSH terms
+    let articles = SearchQuery::new()
+        .mesh_major_topic("COVID-19")
+        .mesh_subheading("prevention & control")
+        .published_after(2023)
+        .limit(5)
+        .search_and_fetch(&client)
+        .await
+        .unwrap();
+
+    assert!(!articles.is_empty());
+
+    // Verify that fetched articles have MeSH terms
+    for article in &articles {
+        println!("Article: {} - {}", article.pmid, article.title);
+        if let Some(_mesh_headings) = &article.mesh_headings {
+            println!("  MeSH terms: {}", article.get_all_mesh_terms().join(", "));
+
+            // Check if COVID-19 is a major topic
+            let major_terms = article.get_major_mesh_terms();
+            println!("  Major topics: {}", major_terms.join(", "));
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore] // This is an integration test that requires network access
+async fn test_chemical_search_integration() {
+    use pubmed_client_rs::ClientConfig;
+
+    let config = ClientConfig::new().with_rate_limit(1.0);
+    let client = PubMedClient::with_config(config);
+
+    // Search for articles about metformin
+    let articles = SearchQuery::new()
+        .mesh_term("Metformin")
+        .mesh_major_topic("Diabetes Mellitus, Type 2")
+        .published_after(2022)
+        .limit(3)
+        .search_and_fetch(&client)
+        .await
+        .unwrap();
+
+    assert!(!articles.is_empty());
+
+    for article in &articles {
+        println!("Article: {} - {}", article.pmid, article.title);
+
+        // Check chemicals
+        let chemicals = article.get_chemical_names();
+        if !chemicals.is_empty() {
+            println!("  Chemicals: {}", chemicals.join(", "));
+        }
+
+        // Check MeSH qualifiers for diabetes
+        let qualifiers = article.get_mesh_qualifiers("Diabetes Mellitus, Type 2");
+        if !qualifiers.is_empty() {
+            println!("  Diabetes qualifiers: {}", qualifiers.join(", "));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements Medical Subject Headings (MeSH) term extraction from PubMed articles
- Adds MeSH-based search capabilities for more precise biomedical literature discovery
- Refactors query module into pubmed module where it belongs

Closes #10

## Changes

### MeSH Data Structures
- Added `MeshTerm`, `MeshQualifier`, `MeshHeading`, `ChemicalConcept`, and `SupplementalConcept` structs
- Updated `PubMedArticle` with `mesh_headings`, `keywords`, and `chemical_list` fields

### XML Parsing
- Implemented comprehensive MeSH parsing logic to extract:
  - MeSH descriptors with major/minor topic indicators
  - MeSH qualifiers (subheadings)
  - Chemical substances with registry numbers
  - Author-provided keywords

### Search Capabilities
- `mesh_major_topic()` - Search by major MeSH topics
- `mesh_term()` and `mesh_terms()` - Search by MeSH terms
- `mesh_subheading()` - Search by MeSH qualifiers
- `clinical_trials_only()` - Filter to clinical trials

### Utility Functions
- `get_major_mesh_terms()` - Extract major MeSH topics
- `has_mesh_term()` - Check for specific MeSH terms
- `get_all_mesh_terms()` - Get all MeSH terms
- `mesh_term_similarity()` - Calculate Jaccard similarity between articles
- `get_mesh_qualifiers()` - Get qualifiers for specific terms
- `has_mesh_terms()` - Check if article has any MeSH terms
- `get_chemical_names()` - Get chemical substances

### Refactoring
- Moved `src/query.rs` → `src/pubmed/query.rs` since it's only used for PubMed searches
- Updated all imports and module declarations accordingly

## Test Plan
- [x] XML parsing tests for MeSH data extraction
- [x] Unit tests for all utility functions
- [x] Query builder tests for MeSH search methods
- [x] Integration tests (marked as ignored for CI)
- [x] All existing tests pass
- [x] Code passes clippy and formatting checks

## Usage Examples

```rust
// MeSH-based searches
let diabetes_articles = SearchQuery::new()
    .mesh_major_topic("Diabetes Mellitus, Type 2")
    .mesh_subheading("drug therapy")
    .published_after(2020)
    .search_and_fetch(&client)
    .await?;

// Extract MeSH information
let article = client.fetch_article("31978945").await?;
let major_terms = article.get_major_mesh_terms();
let similarity = article1.mesh_term_similarity(&article2);
```

🤖 Generated with [Claude Code](https://claude.ai/code)