### PR TITLE
Update PyO3 to Latest Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,11 +2821,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
 dependencies = [
- "cfg-if 1.0.1",
  "indoc",
  "libc",
  "memoffset",
@@ -2839,19 +2838,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2859,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2871,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3759,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"

--- a/pubmed-client-py/Cargo.toml
+++ b/pubmed-client-py/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 pubmed-client = { version = "0.1.0", path = "../pubmed-client" }
 
 # PyO3 for Python bindings
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.27.1", features = ["extension-module"] }
 
 # Re-export some core dependencies
 anyhow = { workspace = true }

--- a/pubmed-client-py/src/client.rs
+++ b/pubmed-client-py/src/client.rs
@@ -88,7 +88,7 @@ impl PyClient {
         limit: usize,
     ) -> PyResult<Vec<(PyPubMedArticle, Option<PyPmcFullText>)>> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let results = rt
                 .block_on(client.search_with_full_text(&query, limit))
@@ -109,7 +109,7 @@ impl PyClient {
     /// Get list of all available NCBI databases
     fn get_database_list(&self, py: Python) -> PyResult<Vec<String>> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             rt.block_on(client.get_database_list()).map_err(to_py_err)
         })
@@ -118,7 +118,7 @@ impl PyClient {
     /// Get detailed information about a specific database
     fn get_database_info(&self, py: Python, database: String) -> PyResult<PyDatabaseInfo> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let info = rt
                 .block_on(client.get_database_info(&database))
@@ -130,7 +130,7 @@ impl PyClient {
     /// Get related articles for given PMIDs
     fn get_related_articles(&self, py: Python, pmids: Vec<u32>) -> PyResult<PyRelatedArticles> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let related = rt
                 .block_on(client.get_related_articles(&pmids))
@@ -142,7 +142,7 @@ impl PyClient {
     /// Get PMC links for given PMIDs
     fn get_pmc_links(&self, py: Python, pmids: Vec<u32>) -> PyResult<PyPmcLinks> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let links = rt
                 .block_on(client.get_pmc_links(&pmids))
@@ -154,7 +154,7 @@ impl PyClient {
     /// Get citing articles for given PMIDs
     fn get_citations(&self, py: Python, pmids: Vec<u32>) -> PyResult<PyCitations> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let citations = rt
                 .block_on(client.get_citations(&pmids))

--- a/pubmed-client-py/src/pmc/client.rs
+++ b/pubmed-client-py/src/pmc/client.rs
@@ -54,7 +54,7 @@ impl PyPmcClient {
     ///     PmcFullText object containing structured article content
     fn fetch_full_text(&self, py: Python, pmcid: String) -> PyResult<PyPmcFullText> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let full_text = rt
                 .block_on(client.fetch_full_text(&pmcid))
@@ -72,7 +72,7 @@ impl PyPmcClient {
     ///     PMC ID if available, None otherwise
     fn check_pmc_availability(&self, py: Python, pmid: String) -> PyResult<Option<String>> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             rt.block_on(client.check_pmc_availability(&pmid))
                 .map_err(to_py_err)

--- a/pubmed-client-py/src/pmc/models.rs
+++ b/pubmed-client-py/src/pmc/models.rs
@@ -84,7 +84,7 @@ impl From<&pmc::Author> for PyPmcAuthor {
 #[pymethods]
 impl PyPmcAuthor {
     /// Get list of affiliations
-    fn affiliations(&self, py: Python) -> PyResult<PyObject> {
+    fn affiliations(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         for affiliation in &self.inner.affiliations {
             let py_affiliation = PyPmcAffiliation::from(affiliation);
@@ -265,7 +265,7 @@ impl From<PmcFullText> for PyPmcFullText {
 #[pymethods]
 impl PyPmcFullText {
     /// Get list of authors
-    fn authors(&self, py: Python) -> PyResult<PyObject> {
+    fn authors(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         for author in &self.inner.authors {
             let py_author = PyPmcAuthor::from(author);
@@ -275,7 +275,7 @@ impl PyPmcFullText {
     }
 
     /// Get list of sections
-    fn sections(&self, py: Python) -> PyResult<PyObject> {
+    fn sections(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         for section in &self.inner.sections {
             let py_section = PyArticleSection::from(section);
@@ -285,7 +285,7 @@ impl PyPmcFullText {
     }
 
     /// Get list of all figures from all sections
-    fn figures(&self, py: Python) -> PyResult<PyObject> {
+    fn figures(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         // Collect figures from all sections recursively
         fn collect_figures(section: &pmc::ArticleSection, figures: &mut Vec<pmc::Figure>) {
@@ -308,7 +308,7 @@ impl PyPmcFullText {
     }
 
     /// Get list of all tables from all sections
-    fn tables(&self, py: Python) -> PyResult<PyObject> {
+    fn tables(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         // Collect tables from all sections recursively
         fn collect_tables(section: &pmc::ArticleSection, tables: &mut Vec<pmc::Table>) {
@@ -331,7 +331,7 @@ impl PyPmcFullText {
     }
 
     /// Get list of references
-    fn references(&self, py: Python) -> PyResult<PyObject> {
+    fn references(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         for reference in &self.inner.references {
             let py_reference = PyReference::from(reference);

--- a/pubmed-client-py/src/pubmed/client.rs
+++ b/pubmed-client-py/src/pubmed/client.rs
@@ -110,7 +110,7 @@ impl PyPubMedClient {
         let query_string = query.to_query_string()?;
         let actual_limit = query.get_limit(limit);
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             rt.block_on(client.search_articles(&query_string, actual_limit))
                 .map_err(to_py_err)
@@ -143,7 +143,7 @@ impl PyPubMedClient {
         let query_string = query.to_query_string()?;
         let actual_limit = query.get_limit(limit);
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let articles = rt
                 .block_on(client.search_and_fetch(&query_string, actual_limit))
@@ -161,7 +161,7 @@ impl PyPubMedClient {
     ///     PubMedArticle object
     fn fetch_article(&self, py: Python, pmid: String) -> PyResult<PyPubMedArticle> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let article = rt
                 .block_on(client.fetch_article(&pmid))
@@ -176,7 +176,7 @@ impl PyPubMedClient {
     ///     List of database names
     fn get_database_list(&self, py: Python) -> PyResult<Vec<String>> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             rt.block_on(client.get_database_list()).map_err(to_py_err)
         })
@@ -191,7 +191,7 @@ impl PyPubMedClient {
     ///     DatabaseInfo object
     fn get_database_info(&self, py: Python, database: String) -> PyResult<PyDatabaseInfo> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let info = rt
                 .block_on(client.get_database_info(&database))
@@ -209,7 +209,7 @@ impl PyPubMedClient {
     ///     RelatedArticles object
     fn get_related_articles(&self, py: Python, pmids: Vec<u32>) -> PyResult<PyRelatedArticles> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let related = rt
                 .block_on(client.get_related_articles(&pmids))
@@ -227,7 +227,7 @@ impl PyPubMedClient {
     ///     PmcLinks object containing available PMC IDs
     fn get_pmc_links(&self, py: Python, pmids: Vec<u32>) -> PyResult<PyPmcLinks> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let links = rt
                 .block_on(client.get_pmc_links(&pmids))
@@ -254,7 +254,7 @@ impl PyPubMedClient {
     ///     Citations object containing citing article PMIDs
     fn get_citations(&self, py: Python, pmids: Vec<u32>) -> PyResult<PyCitations> {
         let client = self.client.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = get_runtime();
             let citations = rt
                 .block_on(client.get_citations(&pmids))

--- a/pubmed-client-py/src/pubmed/models.rs
+++ b/pubmed-client-py/src/pubmed/models.rs
@@ -95,7 +95,7 @@ impl From<&pubmed::Author> for PyAuthor {
 #[pymethods]
 impl PyAuthor {
     /// Get list of affiliations
-    fn affiliations(&self, py: Python) -> PyResult<PyObject> {
+    fn affiliations(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         for affiliation in &self.inner.affiliations {
             let py_affiliation = PyAffiliation::from(affiliation);
@@ -151,7 +151,7 @@ impl From<PubMedArticle> for PyPubMedArticle {
 #[pymethods]
 impl PyPubMedArticle {
     /// Get list of authors
-    fn authors(&self, py: Python) -> PyResult<PyObject> {
+    fn authors(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
         for author in &self.inner.authors {
             let py_author = PyAuthor::from(author);
@@ -161,13 +161,13 @@ impl PyPubMedArticle {
     }
 
     /// Get article types
-    fn article_types(&self, py: Python) -> PyResult<PyObject> {
+    fn article_types(&self, py: Python) -> PyResult<Py<PyAny>> {
         let list = PyList::new(py, &self.inner.article_types)?;
         Ok(list.into())
     }
 
     /// Get keywords
-    fn keywords(&self, py: Python) -> PyResult<PyObject> {
+    fn keywords(&self, py: Python) -> PyResult<Py<PyAny>> {
         match &self.inner.keywords {
             Some(keywords) => {
                 let list = PyList::new(py, keywords)?;


### PR DESCRIPTION
- Update PyO3 from 0.23 to 0.27.1 (latest version)
- Replace deprecated PyObject with Py<PyAny>
- Replace deprecated allow_threads with detach
- All 87 Python tests passing
- Zero compilation warnings

This upgrade adds Python 3.14 support and includes major FromPyObject trait improvements.