### PR TITLE
Add logical operators to Python binding

### DIFF
--- a/pubmed-client-py/pubmed_client.pyi
+++ b/pubmed-client-py/pubmed_client.pyi
@@ -855,6 +855,131 @@ class SearchQuery:
             >>> query.build()
             'genomics AND pmc[sb]'
         """
+    def and_(self, other: SearchQuery) -> SearchQuery:
+        r"""
+        Combine this query with another using AND logic
+
+        Combines two queries by wrapping each in parentheses and joining with AND.
+        If either query is empty, returns the non-empty query.
+        The result uses the higher limit of the two queries.
+
+        Args:
+            other: Another SearchQuery to combine with
+
+        Returns:
+            SearchQuery: New query with combined logic
+
+        Example:
+            >>> q1 = SearchQuery().query("covid-19")
+            >>> q2 = SearchQuery().query("vaccine")
+            >>> combined = q1.and_(q2)
+            >>> combined.build()
+            '(covid-19) AND (vaccine)'
+
+            >>> # Complex chaining
+            >>> result = SearchQuery().query("cancer") \
+            ...     .and_(SearchQuery().query("treatment")) \
+            ...     .and_(SearchQuery().query("2024[pdat]"))
+            >>> result.build()
+            '((cancer) AND (treatment)) AND (2024[pdat])'
+        """
+    def or_(self, other: SearchQuery) -> SearchQuery:
+        r"""
+        Combine this query with another using OR logic
+
+        Combines two queries by wrapping each in parentheses and joining with OR.
+        If either query is empty, returns the non-empty query.
+        The result uses the higher limit of the two queries.
+
+        Args:
+            other: Another SearchQuery to combine with
+
+        Returns:
+            SearchQuery: New query with combined logic
+
+        Example:
+            >>> q1 = SearchQuery().query("diabetes")
+            >>> q2 = SearchQuery().query("hypertension")
+            >>> combined = q1.or_(q2)
+            >>> combined.build()
+            '(diabetes) OR (hypertension)'
+
+            >>> # Find articles about either condition
+            >>> result = SearchQuery().query("cancer") \
+            ...     .or_(SearchQuery().query("tumor")) \
+            ...     .or_(SearchQuery().query("oncology"))
+            >>> result.build()
+            '((cancer) OR (tumor)) OR (oncology)'
+        """
+    def negate(self) -> SearchQuery:
+        r"""
+        Negate this query using NOT logic
+
+        Wraps the current query with NOT operator.
+        This is typically used in combination with other queries to exclude results.
+        Returns an empty query if the current query is empty.
+
+        Returns:
+            SearchQuery: New query with NOT logic
+
+        Example:
+            >>> query = SearchQuery().query("cancer").negate()
+            >>> query.build()
+            'NOT (cancer)'
+
+            >>> # More practical: exclude from search results
+            >>> base = SearchQuery().query("treatment")
+            >>> excluded = SearchQuery().query("animal studies").negate()
+            >>> # (Note: use exclude() method for this pattern)
+        """
+    def exclude(self, excluded: SearchQuery) -> SearchQuery:
+        r"""
+        Exclude articles matching the given query
+
+        Excludes results from this query that match the excluded query.
+        This is the recommended way to filter out unwanted results.
+        If either query is empty, returns the base query unchanged.
+
+        Args:
+            excluded: SearchQuery representing articles to exclude
+
+        Returns:
+            SearchQuery: New query with exclusion logic
+
+        Example:
+            >>> base = SearchQuery().query("cancer treatment")
+            >>> exclude = SearchQuery().query("animal studies")
+            >>> filtered = base.exclude(exclude)
+            >>> filtered.build()
+            '(cancer treatment) NOT (animal studies)'
+
+            >>> # Exclude multiple types of studies
+            >>> human_only = SearchQuery().query("therapy") \
+            ...     .exclude(SearchQuery().query("animal studies")) \
+            ...     .exclude(SearchQuery().query("in vitro"))
+        """
+    def group(self) -> SearchQuery:
+        r"""
+        Add parentheses around the current query for grouping
+
+        Wraps the query in parentheses to control operator precedence in complex queries.
+        Returns an empty query if the current query is empty.
+
+        Returns:
+            SearchQuery: New query wrapped in parentheses
+
+        Example:
+            >>> query = SearchQuery().query("cancer").or_(SearchQuery().query("tumor")).group()
+            >>> query.build()
+            '((cancer) OR (tumor))'
+
+            >>> # Controlling precedence
+            >>> q1 = SearchQuery().query("a").or_(SearchQuery().query("b")).group()
+            >>> q2 = SearchQuery().query("c").or_(SearchQuery().query("d")).group()
+            >>> result = q1.and_(q2)
+            >>> result.build()
+            '(((a) OR (b))) AND (((c) OR (d)))'
+        """
 
 class Table:
     r"""


### PR DESCRIPTION
Add complete support for boolean query operations in Python bindings:

- and_() - Combine queries with AND logic
- or_() - Combine queries with OR logic
- negate() - Negate query with NOT
- exclude() - Exclude results matching another query
- group() - Add parentheses for precedence control

Features:
- All methods support method chaining
- Empty query handling (returns non-empty query)
- Limit preservation (uses higher limit)
- Full type stub support for IDE autocomplete

Testing:
- 23 new comprehensive tests covering all operations
- Edge cases: empty queries, deep nesting, complex chains
- Real-world query examples
- All 65 tests passing

Examples:
  q1 = SearchQuery().query("covid-19") q2 = SearchQuery().query("vaccine") combined = q1.and_(q2) # Result: "(covid-19) AND (vaccine)"

Related files:
- pubmed-client-py/src/query.rs - Boolean method implementations
- pubmed-client-py/pubmed_client.pyi - Type stubs
- pubmed-client-py/tests/test_query.py - Comprehensive tests