### PR TITLE
Implement search query builder for NAPI binding

### DIFF
--- a/pubmed-client-napi/src/lib.rs
+++ b/pubmed-client-napi/src/lib.rs
@@ -4,7 +4,7 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use pubmed_client::{
     pmc::{markdown::PmcMarkdownConverter, PmcFullText},
-    pubmed::PubMedArticle,
+    pubmed::{ArticleType, Language, PubMedArticle, SearchQuery as RustSearchQuery},
     Client, ClientConfig,
 };
 use std::sync::Arc;
@@ -365,5 +365,926 @@ impl PubMedClient {
             .check_pmc_availability(&pmid)
             .await
             .map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    /// Execute a search query and return articles
+    ///
+    /// @param query - SearchQuery instance
+    /// @returns Array of article metadata
+    #[napi]
+    pub async fn execute_query(&self, query: &SearchQuery) -> Result<Vec<Article>> {
+        let query_string = query.inner.build();
+        let limit = query.inner.get_limit();
+        let articles = self
+            .client
+            .pubmed
+            .search_and_fetch(&query_string, limit)
+            .await
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+
+        Ok(articles.into_iter().map(Article::from).collect())
+    }
+}
+
+// ================================================================================================
+// Helper Functions
+// ================================================================================================
+
+/// Validate year is within reasonable range for biomedical publications
+fn validate_year(year: u32) -> Result<()> {
+    if !(1800..=3000).contains(&year) {
+        return Err(Error::from_reason(format!(
+            "Year must be between 1800 and 3000, got: {}",
+            year
+        )));
+    }
+    Ok(())
+}
+
+/// Convert string to ArticleType enum with case-insensitive matching
+fn str_to_article_type(s: &str) -> Result<ArticleType> {
+    let normalized = s.trim().to_lowercase();
+
+    match normalized.as_str() {
+        "clinical trial" => Ok(ArticleType::ClinicalTrial),
+        "review" => Ok(ArticleType::Review),
+        "systematic review" => Ok(ArticleType::SystematicReview),
+        "meta-analysis" | "meta analysis" => Ok(ArticleType::MetaAnalysis),
+        "case reports" | "case report" => Ok(ArticleType::CaseReport),
+        "randomized controlled trial" | "rct" => Ok(ArticleType::RandomizedControlledTrial),
+        "observational study" => Ok(ArticleType::ObservationalStudy),
+        _ => Err(Error::from_reason(format!(
+            "Invalid article type: '{}'. Supported types: Clinical Trial, Review, Systematic Review, Meta-Analysis, Case Reports, Randomized Controlled Trial, Observational Study",
+            s
+        ))),
+    }
+}
+
+/// Convert string to Language enum with case-insensitive matching
+fn str_to_language(s: &str) -> Language {
+    let normalized = s.trim().to_lowercase();
+
+    match normalized.as_str() {
+        "english" => Language::English,
+        "japanese" => Language::Japanese,
+        "german" => Language::German,
+        "french" => Language::French,
+        "spanish" => Language::Spanish,
+        "italian" => Language::Italian,
+        "chinese" => Language::Chinese,
+        "russian" => Language::Russian,
+        "portuguese" => Language::Portuguese,
+        "arabic" => Language::Arabic,
+        "dutch" => Language::Dutch,
+        "korean" => Language::Korean,
+        "polish" => Language::Polish,
+        "swedish" => Language::Swedish,
+        "danish" => Language::Danish,
+        "norwegian" => Language::Norwegian,
+        "finnish" => Language::Finnish,
+        "turkish" => Language::Turkish,
+        "hebrew" => Language::Hebrew,
+        "czech" => Language::Czech,
+        "hungarian" => Language::Hungarian,
+        "greek" => Language::Greek,
+        _ => Language::Other(s.trim().to_string()),
+    }
+}
+
+// ================================================================================================
+// SearchQuery Builder
+// ================================================================================================
+
+/// Builder for constructing PubMed search queries programmatically
+///
+/// Provides a fluent API for building complex PubMed search queries with support for:
+/// - Basic search terms
+/// - Date filtering
+/// - Article type and language filtering
+/// - Open access filtering
+/// - Boolean logic operations (AND, OR, NOT)
+/// - MeSH terms and author filtering
+///
+/// @example
+/// ```typescript
+/// const query = new SearchQuery()
+///   .query("covid-19")
+///   .publishedInYear(2024)
+///   .articleType("Clinical Trial")
+///   .freeFullTextOnly();
+///
+/// const articles = await client.executeQuery(query);
+/// ```
+#[napi]
+pub struct SearchQuery {
+    inner: RustSearchQuery,
+}
+
+impl Default for SearchQuery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[napi]
+impl SearchQuery {
+    /// Create a new empty search query builder
+    #[napi(constructor)]
+    pub fn new() -> Self {
+        SearchQuery {
+            inner: RustSearchQuery::new(),
+        }
+    }
+
+    // ============================================================================================
+    // Basic Methods
+    // ============================================================================================
+
+    /// Add a search term to the query
+    ///
+    /// Terms are accumulated and will be space-separated in the final query.
+    ///
+    /// @param term - Search term string
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("covid-19")
+    ///   .query("treatment");
+    /// query.build(); // "covid-19 treatment"
+    /// ```
+    #[napi]
+    pub fn query(&mut self, term: String) -> &Self {
+        let trimmed = term.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().query(trimmed);
+        }
+        self
+    }
+
+    /// Add multiple search terms at once
+    ///
+    /// Each term is processed like query(). Empty strings are filtered out.
+    ///
+    /// @param terms - Array of search term strings
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .terms(["covid-19", "vaccine", "efficacy"]);
+    /// query.build(); // "covid-19 vaccine efficacy"
+    /// ```
+    #[napi]
+    pub fn terms(&mut self, terms: Vec<String>) -> &Self {
+        for term in terms {
+            let trimmed = term.trim();
+            if !trimmed.is_empty() {
+                self.inner = self.inner.clone().query(trimmed);
+            }
+        }
+        self
+    }
+
+    /// Set the maximum number of results to return
+    ///
+    /// @param limit - Maximum number of results (clamped to 1-10,000 range)
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("cancer")
+    ///   .setLimit(50);
+    /// ```
+    #[napi]
+    pub fn set_limit(&mut self, limit: u32) -> &Self {
+        // Clamp the limit to valid range instead of throwing
+        let clamped_limit = limit.clamp(1, 10000) as usize;
+        self.inner = self.inner.clone().limit(clamped_limit);
+        self
+    }
+
+    /// Build the final PubMed query string
+    ///
+    /// @returns Query string for PubMed E-utilities API
+    /// @throws Error if no search terms have been added
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("covid-19")
+    ///   .query("treatment");
+    /// query.build(); // "covid-19 treatment"
+    /// ```
+    #[napi]
+    pub fn build(&self) -> Result<String> {
+        let query_string = self.inner.build();
+        if query_string.trim().is_empty() {
+            return Err(Error::from_reason(
+                "Cannot build query: no search terms provided",
+            ));
+        }
+        Ok(query_string)
+    }
+
+    /// Get the limit for this query
+    ///
+    /// @returns Maximum number of results (default: 20)
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery().query("cancer").limit(100);
+    /// query.getLimit(); // 100
+    /// ```
+    #[napi(getter)]
+    pub fn get_limit(&self) -> u32 {
+        self.inner.get_limit() as u32
+    }
+
+    // ============================================================================================
+    // Date Filtering Methods
+    // ============================================================================================
+
+    /// Filter to articles published in a specific year
+    ///
+    /// @param year - Year to filter by (must be between 1800 and 3000)
+    /// @returns Self for method chaining
+    /// @throws Error if year is outside valid range
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("covid-19")
+    ///   .publishedInYear(2024);
+    /// ```
+    #[napi]
+    pub fn published_in_year(&mut self, year: u32) -> Result<&Self> {
+        validate_year(year)?;
+        self.inner = self.inner.clone().published_in_year(year);
+        Ok(self)
+    }
+
+    /// Filter by publication date range
+    ///
+    /// @param startYear - Start year (inclusive)
+    /// @param endYear - End year (inclusive, optional)
+    /// @returns Self for method chaining
+    /// @throws Error if years are outside valid range
+    ///
+    /// @example
+    /// ```typescript
+    /// // Filter to 2020-2024
+    /// const query = new SearchQuery()
+    ///   .query("cancer")
+    ///   .publishedBetween(2020, 2024);
+    ///
+    /// // Filter from 2020 onwards
+    /// const query2 = new SearchQuery()
+    ///   .query("treatment")
+    ///   .publishedBetween(2020);
+    /// ```
+    #[napi]
+    pub fn published_between(&mut self, start_year: u32, end_year: Option<u32>) -> Result<&Self> {
+        validate_year(start_year)?;
+
+        if let Some(end) = end_year {
+            validate_year(end)?;
+            if start_year > end {
+                return Err(Error::from_reason(format!(
+                    "Start year ({}) must be <= end year ({})",
+                    start_year, end
+                )));
+            }
+        }
+
+        self.inner = self.inner.clone().published_between(start_year, end_year);
+        Ok(self)
+    }
+
+    /// Filter to articles published after a specific year
+    ///
+    /// @param year - Year after which articles were published
+    /// @returns Self for method chaining
+    /// @throws Error if year is outside valid range
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("crispr")
+    ///   .publishedAfter(2020);
+    /// ```
+    #[napi]
+    pub fn published_after(&mut self, year: u32) -> Result<&Self> {
+        validate_year(year)?;
+        self.inner = self.inner.clone().published_after(year);
+        Ok(self)
+    }
+
+    /// Filter to articles published before a specific year
+    ///
+    /// @param year - Year before which articles were published
+    /// @returns Self for method chaining
+    /// @throws Error if year is outside valid range
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("genome")
+    ///   .publishedBefore(2020);
+    /// ```
+    #[napi]
+    pub fn published_before(&mut self, year: u32) -> Result<&Self> {
+        validate_year(year)?;
+        self.inner = self.inner.clone().published_before(year);
+        Ok(self)
+    }
+
+    // ============================================================================================
+    // Article Type and Language Filtering Methods
+    // ============================================================================================
+
+    /// Filter by a single article type
+    ///
+    /// @param typeName - Article type (case-insensitive)
+    ///   Supported types: "Clinical Trial", "Review", "Systematic Review",
+    ///   "Meta-Analysis", "Case Reports", "Randomized Controlled Trial" (or "RCT"),
+    ///   "Observational Study"
+    /// @returns Self for method chaining
+    /// @throws Error if article type is not recognized
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("cancer")
+    ///   .articleType("Clinical Trial");
+    /// ```
+    #[napi]
+    pub fn article_type(&mut self, type_name: String) -> Result<&Self> {
+        let article_type = str_to_article_type(&type_name)?;
+        self.inner = self.inner.clone().article_type(article_type);
+        Ok(self)
+    }
+
+    /// Filter by multiple article types (OR logic)
+    ///
+    /// @param types - Array of article type names (case-insensitive)
+    /// @returns Self for method chaining
+    /// @throws Error if any article type is not recognized
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("treatment")
+    ///   .articleTypes(["RCT", "Meta-Analysis"]);
+    /// ```
+    #[napi]
+    pub fn article_types(&mut self, types: Vec<String>) -> Result<&Self> {
+        if types.is_empty() {
+            return Ok(self);
+        }
+
+        let article_types: std::result::Result<Vec<ArticleType>, Error> =
+            types.iter().map(|s| str_to_article_type(s)).collect();
+
+        let article_types = article_types?;
+        self.inner = self.inner.clone().article_types(&article_types);
+        Ok(self)
+    }
+
+    /// Filter by language
+    ///
+    /// @param lang - Language name (case-insensitive)
+    ///   Supported: "English", "Japanese", "German", "French", "Spanish", etc.
+    ///   Unknown languages are passed through as custom values.
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("cancer")
+    ///   .language("English");
+    /// ```
+    #[napi]
+    pub fn language(&mut self, lang: String) -> &Self {
+        let language = str_to_language(&lang);
+        self.inner = self.inner.clone().language(language);
+        self
+    }
+
+    // ============================================================================================
+    // Open Access Filtering Methods
+    // ============================================================================================
+
+    /// Filter to articles with free full text (open access)
+    ///
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("cancer")
+    ///   .freeFullTextOnly();
+    /// ```
+    #[napi]
+    pub fn free_full_text_only(&mut self) -> &Self {
+        self.inner = self.inner.clone().free_full_text_only();
+        self
+    }
+
+    /// Filter to articles with full text links (including subscription-based)
+    ///
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("diabetes")
+    ///   .fullTextOnly();
+    /// ```
+    #[napi]
+    pub fn full_text_only(&mut self) -> &Self {
+        self.inner = self.inner.clone().full_text_only();
+        self
+    }
+
+    /// Filter to articles with PMC full text
+    ///
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("genomics")
+    ///   .pmcOnly();
+    /// ```
+    #[napi]
+    pub fn pmc_only(&mut self) -> &Self {
+        self.inner = self.inner.clone().pmc_only();
+        self
+    }
+
+    /// Filter to articles that have abstracts
+    ///
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("genetics")
+    ///   .hasAbstract();
+    /// ```
+    #[napi]
+    pub fn has_abstract(&mut self) -> &Self {
+        self.inner = self.inner.clone().has_abstract();
+        self
+    }
+
+    // ============================================================================================
+    // Field-Specific Search Methods
+    // ============================================================================================
+
+    /// Search in article titles only
+    ///
+    /// @param text - Title text to search for
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .titleContains("machine learning");
+    /// ```
+    #[napi]
+    pub fn title_contains(&mut self, text: String) -> &Self {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().title_contains(trimmed);
+        }
+        self
+    }
+
+    /// Search in article abstracts only
+    ///
+    /// @param text - Abstract text to search for
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .abstractContains("neural networks");
+    /// ```
+    #[napi]
+    pub fn abstract_contains(&mut self, text: String) -> &Self {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().abstract_contains(trimmed);
+        }
+        self
+    }
+
+    /// Search in both title and abstract
+    ///
+    /// @param text - Text to search for in title or abstract
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .titleOrAbstract("CRISPR gene editing");
+    /// ```
+    #[napi]
+    pub fn title_or_abstract(&mut self, text: String) -> &Self {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().title_or_abstract(trimmed);
+        }
+        self
+    }
+
+    /// Filter by journal name
+    ///
+    /// @param name - Journal name to search for
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("cancer")
+    ///   .journal("Nature");
+    /// ```
+    #[napi]
+    pub fn journal(&mut self, name: String) -> &Self {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().journal(trimmed);
+        }
+        self
+    }
+
+    /// Filter by grant number
+    ///
+    /// @param grantNumber - Grant number to search for
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .grantNumber("R01AI123456");
+    /// ```
+    #[napi]
+    pub fn grant_number(&mut self, grant_number: String) -> &Self {
+        let trimmed = grant_number.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().grant_number(trimmed);
+        }
+        self
+    }
+
+    // ============================================================================================
+    // Advanced Search Methods (MeSH, Author, etc.)
+    // ============================================================================================
+
+    /// Filter by MeSH term
+    ///
+    /// @param term - MeSH term to filter by
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .meshTerm("Neoplasms");
+    /// ```
+    #[napi]
+    pub fn mesh_term(&mut self, term: String) -> &Self {
+        let trimmed = term.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().mesh_term(trimmed);
+        }
+        self
+    }
+
+    /// Filter by MeSH major topic
+    ///
+    /// @param term - MeSH term to filter by as a major topic
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .meshMajorTopic("Diabetes Mellitus, Type 2");
+    /// ```
+    #[napi]
+    pub fn mesh_major_topic(&mut self, term: String) -> &Self {
+        let trimmed = term.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().mesh_major_topic(trimmed);
+        }
+        self
+    }
+
+    /// Filter by multiple MeSH terms
+    ///
+    /// @param terms - Array of MeSH terms to filter by
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .meshTerms(["Neoplasms", "Antineoplastic Agents"]);
+    /// ```
+    #[napi]
+    pub fn mesh_terms(&mut self, terms: Vec<String>) -> &Self {
+        let valid_terms: Vec<&str> = terms
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !valid_terms.is_empty() {
+            self.inner = self.inner.clone().mesh_terms(&valid_terms);
+        }
+        self
+    }
+
+    /// Filter by MeSH subheading
+    ///
+    /// @param subheading - MeSH subheading to filter by
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .meshTerm("Diabetes Mellitus")
+    ///   .meshSubheading("drug therapy");
+    /// ```
+    #[napi]
+    pub fn mesh_subheading(&mut self, subheading: String) -> &Self {
+        let trimmed = subheading.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().mesh_subheading(trimmed);
+        }
+        self
+    }
+
+    /// Filter by author name
+    ///
+    /// @param name - Author name to search for
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("machine learning")
+    ///   .author("Williams K");
+    /// ```
+    #[napi]
+    pub fn author(&mut self, name: String) -> &Self {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().author(trimmed);
+        }
+        self
+    }
+
+    /// Filter by first author
+    ///
+    /// @param name - First author name to search for
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("cancer")
+    ///   .firstAuthor("Smith J");
+    /// ```
+    #[napi]
+    pub fn first_author(&mut self, name: String) -> &Self {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().first_author(trimmed);
+        }
+        self
+    }
+
+    /// Filter by last author
+    ///
+    /// @param name - Last author name to search for
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("genomics")
+    ///   .lastAuthor("Johnson M");
+    /// ```
+    #[napi]
+    pub fn last_author(&mut self, name: String) -> &Self {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().last_author(trimmed);
+        }
+        self
+    }
+
+    /// Filter by institution/affiliation
+    ///
+    /// @param institution - Institution name to search for
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("cardiology")
+    ///   .affiliation("Harvard Medical School");
+    /// ```
+    #[napi]
+    pub fn affiliation(&mut self, institution: String) -> &Self {
+        let trimmed = institution.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().affiliation(trimmed);
+        }
+        self
+    }
+
+    /// Filter by ORCID identifier
+    ///
+    /// @param orcidId - ORCID identifier to search for
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .orcid("0000-0001-2345-6789");
+    /// ```
+    #[napi]
+    pub fn orcid(&mut self, orcid_id: String) -> &Self {
+        let trimmed = orcid_id.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().orcid(trimmed);
+        }
+        self
+    }
+
+    /// Filter to human studies only
+    ///
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("drug treatment")
+    ///   .humanStudiesOnly();
+    /// ```
+    #[napi]
+    pub fn human_studies_only(&mut self) -> &Self {
+        self.inner = self.inner.clone().human_studies_only();
+        self
+    }
+
+    /// Filter to animal studies only
+    ///
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("preclinical research")
+    ///   .animalStudiesOnly();
+    /// ```
+    #[napi]
+    pub fn animal_studies_only(&mut self) -> &Self {
+        self.inner = self.inner.clone().animal_studies_only();
+        self
+    }
+
+    /// Filter by age group
+    ///
+    /// @param ageGroup - Age group to filter by (e.g., "Child", "Adult", "Aged")
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("pediatric medicine")
+    ///   .ageGroup("Child");
+    /// ```
+    #[napi]
+    pub fn age_group(&mut self, age_group: String) -> &Self {
+        let trimmed = age_group.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().age_group(trimmed);
+        }
+        self
+    }
+
+    /// Add a custom filter
+    ///
+    /// @param filter - Custom filter string in PubMed syntax
+    /// @returns Self for method chaining
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("research")
+    ///   .customFilter("humans[mh]");
+    /// ```
+    #[napi]
+    pub fn custom_filter(&mut self, filter: String) -> &Self {
+        let trimmed = filter.trim();
+        if !trimmed.is_empty() {
+            self.inner = self.inner.clone().custom_filter(trimmed);
+        }
+        self
+    }
+
+    // ============================================================================================
+    // Boolean Logic Methods
+    // ============================================================================================
+
+    /// Combine this query with another using AND logic
+    ///
+    /// @param other - Another SearchQuery to combine with
+    /// @returns New SearchQuery with combined logic
+    ///
+    /// @example
+    /// ```typescript
+    /// const q1 = new SearchQuery().query("covid-19");
+    /// const q2 = new SearchQuery().query("vaccine");
+    /// const combined = q1.and(q2);
+    /// combined.build(); // "(covid-19) AND (vaccine)"
+    /// ```
+    #[napi]
+    pub fn and(&self, other: &SearchQuery) -> SearchQuery {
+        let combined = self.inner.clone().and(other.inner.clone());
+        SearchQuery { inner: combined }
+    }
+
+    /// Combine this query with another using OR logic
+    ///
+    /// @param other - Another SearchQuery to combine with
+    /// @returns New SearchQuery with combined logic
+    ///
+    /// @example
+    /// ```typescript
+    /// const q1 = new SearchQuery().query("diabetes");
+    /// const q2 = new SearchQuery().query("hypertension");
+    /// const combined = q1.or(q2);
+    /// combined.build(); // "(diabetes) OR (hypertension)"
+    /// ```
+    #[napi]
+    pub fn or(&self, other: &SearchQuery) -> SearchQuery {
+        let combined = self.inner.clone().or(other.inner.clone());
+        SearchQuery { inner: combined }
+    }
+
+    /// Negate this query using NOT logic
+    ///
+    /// @returns New SearchQuery with NOT logic
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery().query("cancer").negate();
+    /// query.build(); // "NOT (cancer)"
+    /// ```
+    #[napi]
+    pub fn negate(&self) -> SearchQuery {
+        let negated = self.inner.clone().negate();
+        SearchQuery { inner: negated }
+    }
+
+    /// Exclude articles matching the given query
+    ///
+    /// @param excluded - SearchQuery representing articles to exclude
+    /// @returns New SearchQuery with exclusion logic
+    ///
+    /// @example
+    /// ```typescript
+    /// const base = new SearchQuery().query("cancer treatment");
+    /// const exclude = new SearchQuery().query("animal studies");
+    /// const filtered = base.exclude(exclude);
+    /// filtered.build(); // "(cancer treatment) NOT (animal studies)"
+    /// ```
+    #[napi]
+    pub fn exclude(&self, excluded: &SearchQuery) -> SearchQuery {
+        let filtered = self.inner.clone().exclude(excluded.inner.clone());
+        SearchQuery { inner: filtered }
+    }
+
+    /// Add parentheses around the current query for grouping
+    ///
+    /// @returns New SearchQuery wrapped in parentheses
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("cancer")
+    ///   .or(new SearchQuery().query("tumor"))
+    ///   .group();
+    /// query.build(); // "((cancer) OR (tumor))"
+    /// ```
+    #[napi]
+    pub fn group(&self) -> SearchQuery {
+        let grouped = self.inner.clone().group();
+        SearchQuery { inner: grouped }
     }
 }

--- a/pubmed-client-napi/tests/search-query.test.ts
+++ b/pubmed-client-napi/tests/search-query.test.ts
@@ -1,0 +1,537 @@
+import { describe, expect, it } from 'vitest'
+import { PubMedClient, SearchQuery } from '../index.js'
+import { isNetworkError, TEST_CONFIG } from './setup'
+
+describe('SearchQuery', () => {
+  describe('Basic Methods', () => {
+    it('should create a new SearchQuery', () => {
+      const query = new SearchQuery()
+      expect(query).toBeDefined()
+    })
+
+    it('should add search terms with query()', () => {
+      const query = new SearchQuery()
+        .query('covid-19')
+        .query('treatment')
+
+      const result = query.build()
+      expect(result).toBe('covid-19 treatment')
+    })
+
+    it('should add multiple search terms with terms()', () => {
+      const query = new SearchQuery()
+        .terms(['covid-19', 'vaccine', 'efficacy'])
+
+      const result = query.build()
+      expect(result).toBe('covid-19 vaccine efficacy')
+    })
+
+    it('should filter empty strings in query()', () => {
+      const query = new SearchQuery()
+        .query('covid-19')
+        .query('')
+        .query('  ')
+        .query('treatment')
+
+      const result = query.build()
+      expect(result).toBe('covid-19 treatment')
+    })
+
+    it('should filter empty strings in terms()', () => {
+      const query = new SearchQuery()
+        .terms(['covid-19', '', '  ', 'vaccine'])
+
+      const result = query.build()
+      expect(result).toBe('covid-19 vaccine')
+    })
+
+    it('should throw error when building empty query', () => {
+      const query = new SearchQuery()
+      expect(() => query.build()).toThrow()
+    })
+
+    it('should set and get limit', () => {
+      const query = new SearchQuery()
+        .query('cancer')
+        .setLimit(100)
+
+      expect(query.limit).toBe(100)
+    })
+
+    it('should have default limit of 20', () => {
+      const query = new SearchQuery().query('cancer')
+      expect(query.limit).toBe(20)
+    })
+
+    it('should clamp limit to minimum of 1', () => {
+      const query = new SearchQuery().query('cancer').setLimit(0)
+      expect(query.limit).toBe(1)
+    })
+
+    it('should clamp limit to maximum of 10000', () => {
+      const query = new SearchQuery().query('cancer').setLimit(20000)
+      expect(query.limit).toBe(10000)
+    })
+  })
+
+  describe('Date Filtering Methods', () => {
+    it('should filter by published in year', () => {
+      const query = new SearchQuery()
+        .query('covid-19')
+        .publishedInYear(2024)
+
+      const result = query.build()
+      expect(result).toContain('2024[pdat]')
+    })
+
+    it('should filter by published between years', () => {
+      const query = new SearchQuery()
+        .query('cancer')
+        .publishedBetween(2020, 2024)
+
+      const result = query.build()
+      expect(result).toContain('2020:2024[pdat]')
+    })
+
+    it('should filter by published after year', () => {
+      const query = new SearchQuery()
+        .query('crispr')
+        .publishedAfter(2020)
+
+      const result = query.build()
+      expect(result).toContain('2020:3000[pdat]')
+    })
+
+    it('should filter by published before year', () => {
+      const query = new SearchQuery()
+        .query('genome')
+        .publishedBefore(2020)
+
+      const result = query.build()
+      expect(result).toContain('1900:2020[pdat]')
+    })
+
+    it('should throw error for invalid year', () => {
+      const query = new SearchQuery().query('cancer')
+      expect(() => query.publishedInYear(1700)).toThrow()
+      expect(() => query.publishedInYear(3500)).toThrow()
+    })
+
+    it('should throw error when start year > end year', () => {
+      const query = new SearchQuery().query('cancer')
+      expect(() => query.publishedBetween(2024, 2020)).toThrow()
+    })
+  })
+
+  describe('Article Type and Language Filtering', () => {
+    it('should filter by article type', () => {
+      const query = new SearchQuery()
+        .query('cancer')
+        .articleType('Clinical Trial')
+
+      const result = query.build()
+      expect(result).toContain('Clinical Trial[pt]')
+    })
+
+    it('should filter by article type case-insensitively', () => {
+      const query = new SearchQuery()
+        .query('cancer')
+        .articleType('clinical trial')
+
+      const result = query.build()
+      expect(result).toContain('Clinical Trial[pt]')
+    })
+
+    it('should filter by RCT shorthand', () => {
+      const query = new SearchQuery()
+        .query('treatment')
+        .articleType('RCT')
+
+      const result = query.build()
+      expect(result).toContain('Randomized Controlled Trial[pt]')
+    })
+
+    it('should filter by multiple article types', () => {
+      const query = new SearchQuery()
+        .query('treatment')
+        .articleTypes(['RCT', 'Meta-Analysis'])
+
+      const result = query.build()
+      expect(result).toContain('Randomized Controlled Trial[pt]')
+      expect(result).toContain('Meta-Analysis[pt]')
+    })
+
+    it('should throw error for invalid article type', () => {
+      const query = new SearchQuery().query('cancer')
+      expect(() => query.articleType('invalid type')).toThrow()
+    })
+
+    it('should filter by language', () => {
+      const query = new SearchQuery()
+        .query('cancer')
+        .language('English')
+
+      const result = query.build()
+      expect(result).toContain('English[la]')
+    })
+
+    it('should filter by language case-insensitively', () => {
+      const query = new SearchQuery()
+        .query('cancer')
+        .language('japanese')
+
+      const result = query.build()
+      expect(result).toContain('Japanese[la]')
+    })
+
+    it('should handle custom language', () => {
+      const query = new SearchQuery()
+        .query('research')
+        .language('Esperanto')
+
+      const result = query.build()
+      expect(result).toContain('Esperanto[la]')
+    })
+  })
+
+  describe('Open Access Filtering', () => {
+    it('should filter by free full text', () => {
+      const query = new SearchQuery()
+        .query('cancer')
+        .freeFullTextOnly()
+
+      const result = query.build()
+      expect(result).toContain('free full text[sb]')
+    })
+
+    it('should filter by full text', () => {
+      const query = new SearchQuery()
+        .query('diabetes')
+        .fullTextOnly()
+
+      const result = query.build()
+      expect(result).toContain('full text[sb]')
+    })
+
+    it('should filter by PMC only', () => {
+      const query = new SearchQuery()
+        .query('genomics')
+        .pmcOnly()
+
+      const result = query.build()
+      expect(result).toContain('pubmed pmc[sb]')
+    })
+
+    it('should filter by has abstract', () => {
+      const query = new SearchQuery()
+        .query('genetics')
+        .hasAbstract()
+
+      const result = query.build()
+      expect(result).toContain('hasabstract')
+    })
+  })
+
+  describe('Field-Specific Search', () => {
+    it('should search in title', () => {
+      const query = new SearchQuery()
+        .titleContains('machine learning')
+
+      const result = query.build()
+      expect(result).toContain('machine learning[ti]')
+    })
+
+    it('should search in abstract', () => {
+      const query = new SearchQuery()
+        .abstractContains('neural networks')
+
+      const result = query.build()
+      expect(result).toContain('neural networks[tiab]')
+    })
+
+    it('should search in title or abstract', () => {
+      const query = new SearchQuery()
+        .titleOrAbstract('CRISPR')
+
+      const result = query.build()
+      expect(result).toContain('CRISPR[tiab]')
+    })
+
+    it('should filter by journal', () => {
+      const query = new SearchQuery()
+        .query('cancer')
+        .journal('Nature')
+
+      const result = query.build()
+      expect(result).toContain('Nature[ta]')
+    })
+
+    it('should filter by grant number', () => {
+      const query = new SearchQuery()
+        .grantNumber('R01AI123456')
+
+      const result = query.build()
+      expect(result).toContain('R01AI123456[gr]')
+    })
+  })
+
+  describe('Advanced Search Methods', () => {
+    it('should filter by MeSH term', () => {
+      const query = new SearchQuery()
+        .meshTerm('Neoplasms')
+
+      const result = query.build()
+      expect(result).toContain('Neoplasms[mh]')
+    })
+
+    it('should filter by MeSH major topic', () => {
+      const query = new SearchQuery()
+        .meshMajorTopic('Diabetes Mellitus')
+
+      const result = query.build()
+      expect(result).toContain('Diabetes Mellitus[majr]')
+    })
+
+    it('should filter by multiple MeSH terms', () => {
+      const query = new SearchQuery()
+        .meshTerms(['Neoplasms', 'Antineoplastic Agents'])
+
+      const result = query.build()
+      expect(result).toContain('Neoplasms[mh]')
+      expect(result).toContain('Antineoplastic Agents[mh]')
+    })
+
+    it('should filter by MeSH subheading', () => {
+      const query = new SearchQuery()
+        .meshTerm('Diabetes Mellitus')
+        .meshSubheading('drug therapy')
+
+      const result = query.build()
+      expect(result).toContain('Diabetes Mellitus[mh]')
+      expect(result).toContain('drug therapy[sh]')
+    })
+
+    it('should filter by author', () => {
+      const query = new SearchQuery()
+        .query('machine learning')
+        .author('Williams K')
+
+      const result = query.build()
+      expect(result).toContain('Williams K[au]')
+    })
+
+    it('should filter by first author', () => {
+      const query = new SearchQuery()
+        .query('cancer')
+        .firstAuthor('Smith J')
+
+      const result = query.build()
+      expect(result).toContain('Smith J[1au]')
+    })
+
+    it('should filter by last author', () => {
+      const query = new SearchQuery()
+        .query('genomics')
+        .lastAuthor('Johnson M')
+
+      const result = query.build()
+      expect(result).toContain('Johnson M[lastau]')
+    })
+
+    it('should filter by affiliation', () => {
+      const query = new SearchQuery()
+        .query('cardiology')
+        .affiliation('Harvard Medical School')
+
+      const result = query.build()
+      expect(result).toContain('Harvard Medical School[ad]')
+    })
+
+    it('should filter by ORCID', () => {
+      const query = new SearchQuery()
+        .orcid('0000-0001-2345-6789')
+
+      const result = query.build()
+      expect(result).toContain('0000-0001-2345-6789[auid]')
+    })
+
+    it('should filter by human studies only', () => {
+      const query = new SearchQuery()
+        .query('drug treatment')
+        .humanStudiesOnly()
+
+      const result = query.build()
+      expect(result).toContain('humans[mh]')
+    })
+
+    it('should filter by animal studies only', () => {
+      const query = new SearchQuery()
+        .query('preclinical research')
+        .animalStudiesOnly()
+
+      const result = query.build()
+      expect(result).toContain('animals[mh]')
+    })
+
+    it('should filter by age group', () => {
+      const query = new SearchQuery()
+        .query('pediatric medicine')
+        .ageGroup('Child')
+
+      const result = query.build()
+      expect(result).toContain('Child[mh]')
+    })
+
+    it('should add custom filter', () => {
+      const query = new SearchQuery()
+        .query('research')
+        .customFilter('humans[mh]')
+
+      const result = query.build()
+      expect(result).toContain('humans[mh]')
+    })
+  })
+
+  describe('Boolean Logic Methods', () => {
+    it('should combine queries with AND', () => {
+      const q1 = new SearchQuery().query('covid-19')
+      const q2 = new SearchQuery().query('vaccine')
+      const combined = q1.and(q2)
+
+      const result = combined.build()
+      expect(result).toBe('(covid-19) AND (vaccine)')
+    })
+
+    it('should combine queries with OR', () => {
+      const q1 = new SearchQuery().query('diabetes')
+      const q2 = new SearchQuery().query('hypertension')
+      const combined = q1.or(q2)
+
+      const result = combined.build()
+      expect(result).toBe('(diabetes) OR (hypertension)')
+    })
+
+    it('should negate a query', () => {
+      const query = new SearchQuery().query('cancer').negate()
+
+      const result = query.build()
+      expect(result).toBe('NOT (cancer)')
+    })
+
+    it('should exclude a query', () => {
+      const base = new SearchQuery().query('cancer treatment')
+      const exclude = new SearchQuery().query('animal studies')
+      const filtered = base.exclude(exclude)
+
+      const result = filtered.build()
+      expect(result).toBe('(cancer treatment) NOT (animal studies)')
+    })
+
+    it('should group a query', () => {
+      const query = new SearchQuery().query('cancer').group()
+
+      const result = query.build()
+      expect(result).toBe('(cancer)')
+    })
+
+    it('should handle complex boolean chaining', () => {
+      const q1 = new SearchQuery().query('machine learning')
+      const q2 = new SearchQuery().query('medicine')
+      const q3 = new SearchQuery().query('veterinary')
+
+      const combined = q1.and(q2).exclude(q3)
+
+      const result = combined.build()
+      expect(result).toBe('((machine learning) AND (medicine)) NOT (veterinary)')
+    })
+  })
+
+  describe('Complex Query Building', () => {
+    it('should build complex query with multiple filters', () => {
+      const query = new SearchQuery()
+        .query('covid-19 treatment')
+        .titleContains('immunotherapy')
+        .journal('Nature')
+        .freeFullTextOnly()
+        .articleType('Clinical Trial')
+        .language('English')
+        .publishedBetween(2020, 2024)
+
+      const result = query.build()
+      expect(result).toContain('covid-19 treatment')
+      expect(result).toContain('immunotherapy[ti]')
+      expect(result).toContain('Nature[ta]')
+      expect(result).toContain('free full text[sb]')
+      expect(result).toContain('Clinical Trial[pt]')
+      expect(result).toContain('English[la]')
+      expect(result).toContain('2020:2024[pdat]')
+    })
+
+    it('should build query with MeSH and author filters', () => {
+      const query = new SearchQuery()
+        .meshTerm('Neoplasms')
+        .author('Smith J')
+        .humanStudiesOnly()
+        .affiliation('Harvard')
+
+      const result = query.build()
+      expect(result).toContain('Neoplasms[mh]')
+      expect(result).toContain('Smith J[au]')
+      expect(result).toContain('humans[mh]')
+      expect(result).toContain('Harvard[ad]')
+    })
+  })
+
+  describe('Integration with PubMedClient', () => {
+    it('should execute query with client', async () => {
+      const client = new PubMedClient()
+      const query = new SearchQuery()
+        .query(TEST_CONFIG.TEST_QUERY)
+        .setLimit(3)
+
+      try {
+        const articles = await client.executeQuery(query)
+
+        expect(Array.isArray(articles)).toBe(true)
+        expect(articles.length).toBeGreaterThan(0)
+        expect(articles.length).toBeLessThanOrEqual(3)
+
+        const article = articles[0]
+        expect(article.pmid).toBeDefined()
+        expect(article.title).toBeDefined()
+      } catch (error) {
+        if (isNetworkError(error)) {
+          console.warn('Skipping integration test due to API/network issue:', error)
+          return
+        }
+        throw error
+      }
+    })
+
+    it('should execute complex query with client', async () => {
+      const client = new PubMedClient()
+      const query = new SearchQuery()
+        .query('covid-19')
+        .publishedBetween(2023, 2024)
+        .freeFullTextOnly()
+        .language('English')
+        .setLimit(5)
+
+      try {
+        const articles = await client.executeQuery(query)
+
+        expect(Array.isArray(articles)).toBe(true)
+        // Should return results given the broad search
+        if (articles.length > 0) {
+          expect(articles[0].pmid).toBeDefined()
+        }
+      } catch (error) {
+        if (isNetworkError(error)) {
+          console.warn('Skipping complex query test due to API/network issue:', error)
+          return
+        }
+        throw error
+      }
+    })
+  })
+})


### PR DESCRIPTION
Implement a comprehensive SearchQuery builder for Node.js/TypeScript with:

- Basic methods: query, terms, setLimit, build, getLimit
- Date filtering: publishedInYear, publishedBetween, publishedAfter, publishedBefore
- Article type and language: articleType, articleTypes, language
- Open access: freeFullTextOnly, fullTextOnly, pmcOnly, hasAbstract
- Field search: titleContains, abstractContains, titleOrAbstract, journal, grantNumber
- Advanced: meshTerm, meshMajorTopic, meshTerms, meshSubheading, author, firstAuthor, lastAuthor, affiliation, orcid, humanStudiesOnly, animalStudiesOnly, ageGroup, customFilter
- Boolean logic: and, or, negate, exclude, group
- Integration: executeQuery method on PubMedClient

Also add comprehensive TypeScript tests covering all methods.