### PR TITLE
fix: enable proper rate limiting for WASM targets using gloo-timers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,6 +1653,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-utils"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2972,7 +2984,9 @@ dependencies = [
  "flate2",
  "futures-util",
  "getrandom 0.2.16",
+ "gloo-timers",
  "image",
+ "js-sys",
  "moka",
  "paste",
  "quick-xml",

--- a/pubmed-client/Cargo.toml
+++ b/pubmed-client/Cargo.toml
@@ -40,8 +40,10 @@ image = "0.24"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { version = "0.11", features = ["json"], default-features = false }
-tokio = { version = "1.0", features = ["macros", "rt", "time"], default-features = false }
+tokio = { version = "1.0", features = ["macros", "rt"], default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
+js-sys = "0.3"
 
 [features]
 default = ["native-tls"]


### PR DESCRIPTION
Previously, the WASM implementation of sleep() returned immediately and Instant::duration_since() always returned zero, making rate limiting ineffective in browser environments. This could lead to 429 errors when using Promise.all() with multiple concurrent requests.

Changes:
- Add gloo-timers and js-sys dependencies for WASM target
- Implement sleep() using gloo_timers::future::TimeoutFuture
- Implement Instant using js_sys::Date::now() for proper time measurement
- Fix native sleep() to use millisecond precision instead of seconds
- Add test for Instant::duration_since() accuracy