### PR TITLE
Add sort order support and query translation to search API

### DIFF
--- a/pubmed-client-napi/src/lib.rs
+++ b/pubmed-client-napi/src/lib.rs
@@ -4,7 +4,7 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use pubmed_client::{
     pmc::{markdown::PmcMarkdownConverter, PmcFullText},
-    pubmed::{ArticleType, Language, PubMedArticle, SearchQuery as RustSearchQuery},
+    pubmed::{ArticleType, Language, PubMedArticle, SearchQuery as RustSearchQuery, SortOrder},
     Client, ClientConfig,
 };
 use std::sync::Arc;
@@ -514,6 +514,22 @@ fn str_to_article_type(s: &str) -> Result<ArticleType> {
         "observational study" => Ok(ArticleType::ObservationalStudy),
         _ => Err(Error::from_reason(format!(
             "Invalid article type: '{}'. Supported types: Clinical Trial, Review, Systematic Review, Meta-Analysis, Case Reports, Randomized Controlled Trial, Observational Study",
+            s
+        ))),
+    }
+}
+
+/// Convert string to SortOrder enum with case-insensitive matching
+fn str_to_sort_order(s: &str) -> Result<SortOrder> {
+    let normalized = s.trim().to_lowercase();
+
+    match normalized.as_str() {
+        "relevance" => Ok(SortOrder::Relevance),
+        "pub_date" | "publication_date" | "date" => Ok(SortOrder::PublicationDate),
+        "author" | "first_author" => Ok(SortOrder::FirstAuthor),
+        "journal" | "journal_name" => Ok(SortOrder::JournalName),
+        _ => Err(Error::from_reason(format!(
+            "Invalid sort order: '{}'. Supported values: relevance, pub_date, author, journal",
             s
         ))),
     }
@@ -1385,5 +1401,29 @@ impl SearchQuery {
     pub fn group(&self) -> SearchQuery {
         let grouped = self.inner.clone().group();
         SearchQuery { inner: grouped }
+    }
+
+    // ============================================================================================
+    // Sort Methods
+    // ============================================================================================
+
+    /// Set the sort order for search results
+    ///
+    /// @param sortOrder - Sort order (case-insensitive)
+    ///   Supported: "relevance", "pub_date", "author", "journal"
+    /// @returns Self for method chaining
+    /// @throws Error if sort order is not recognized
+    ///
+    /// @example
+    /// ```typescript
+    /// const query = new SearchQuery()
+    ///   .query("cancer")
+    ///   .sort("pub_date");
+    /// ```
+    #[napi]
+    pub fn sort(&mut self, sort_order: String) -> Result<&Self> {
+        let sort = str_to_sort_order(&sort_order)?;
+        self.inner = self.inner.clone().sort(sort);
+        Ok(self)
     }
 }

--- a/pubmed-client/Cargo.toml
+++ b/pubmed-client/Cargo.toml
@@ -159,5 +159,10 @@ path = "tests/integration/test_batch_fetch_mocked.rs"
 name = "test_batch_fetch_api"
 path = "tests/integration/test_batch_fetch_api.rs"
 
+# Search options tests (sort, query translation)
+[[test]]
+name = "test_search_options"
+path = "tests/integration/test_search_options.rs"
+
 # Examples
 # (Python examples are in pubmed-client-py/examples/)

--- a/pubmed-client/src/lib.rs
+++ b/pubmed-client/src/lib.rs
@@ -283,7 +283,7 @@ pub use pubmed::{
     parse_article_from_xml, ArticleType, CitationMatch, CitationMatchStatus, CitationMatches,
     CitationQuery, Citations, DatabaseCount, DatabaseInfo, FieldInfo, GlobalQueryResults,
     HistorySession, Language, LinkInfo, PmcLinks, PubMedArticle, PubMedClient, RelatedArticles,
-    SearchQuery, SearchResult,
+    SearchQuery, SearchResult, SortOrder,
 };
 pub use rate_limit::RateLimiter;
 pub use time::{sleep, Duration, Instant};

--- a/pubmed-client/src/pubmed/mod.rs
+++ b/pubmed-client/src/pubmed/mod.rs
@@ -18,4 +18,4 @@ pub use models::{
     RelatedArticles, SearchResult, SupplementalConcept,
 };
 pub use parser::{parse_article_from_xml, parse_articles_from_xml};
-pub use query::{ArticleType, Language, PubDate, SearchQuery};
+pub use query::{ArticleType, Language, PubDate, SearchQuery, SortOrder};

--- a/pubmed-client/src/pubmed/models.rs
+++ b/pubmed-client/src/pubmed/models.rs
@@ -133,6 +133,14 @@ pub struct SearchResult {
     pub webenv: Option<String>,
     /// Query key for history server
     pub query_key: Option<String>,
+    /// How PubMed interpreted and translated the search query
+    ///
+    /// For example, searching "asthma" might be translated to:
+    /// `"asthma"[MeSH Terms] OR "asthma"[All Fields]`
+    ///
+    /// This is useful for debugging search queries and understanding
+    /// how PubMed's automatic term mapping works.
+    pub query_translation: Option<String>,
 }
 
 impl SearchResult {

--- a/pubmed-client/src/pubmed/query/filters.rs
+++ b/pubmed-client/src/pubmed/query/filters.rs
@@ -1,5 +1,35 @@
 //! Filter types and enums for PubMed query filtering
 
+/// Sort order for PubMed search results
+///
+/// Controls how ESearch results are ordered. The default sort (when not specified)
+/// is by relevance for most queries.
+///
+/// See: <https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch>
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SortOrder {
+    /// Sort by relevance (default PubMed behavior)
+    Relevance,
+    /// Sort by publication date (newest first)
+    PublicationDate,
+    /// Sort by first author name (alphabetical)
+    FirstAuthor,
+    /// Sort by journal name (alphabetical)
+    JournalName,
+}
+
+impl SortOrder {
+    /// Get the API parameter value for this sort order
+    pub(crate) fn as_api_param(&self) -> &str {
+        match self {
+            SortOrder::Relevance => "relevance",
+            SortOrder::PublicationDate => "pub_date",
+            SortOrder::FirstAuthor => "Author",
+            SortOrder::JournalName => "JournalName",
+        }
+    }
+}
+
 /// Article types that can be filtered in PubMed searches
 #[derive(Debug, Clone, PartialEq)]
 pub enum ArticleType {
@@ -257,6 +287,29 @@ mod tests {
             );
             query_strings.push(query_string);
         }
+    }
+
+    #[test]
+    fn test_sort_order_as_api_param() {
+        assert_eq!(SortOrder::Relevance.as_api_param(), "relevance");
+        assert_eq!(SortOrder::PublicationDate.as_api_param(), "pub_date");
+        assert_eq!(SortOrder::FirstAuthor.as_api_param(), "Author");
+        assert_eq!(SortOrder::JournalName.as_api_param(), "JournalName");
+    }
+
+    #[test]
+    fn test_sort_order_equality() {
+        assert_eq!(SortOrder::Relevance, SortOrder::Relevance);
+        assert_ne!(SortOrder::Relevance, SortOrder::PublicationDate);
+        assert_ne!(SortOrder::FirstAuthor, SortOrder::JournalName);
+    }
+
+    #[test]
+    fn test_sort_order_clone() {
+        let original = SortOrder::PublicationDate;
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+        assert_eq!(original.as_api_param(), cloned.as_api_param());
     }
 
     #[test]

--- a/pubmed-client/src/pubmed/query/mod.rs
+++ b/pubmed-client/src/pubmed/query/mod.rs
@@ -58,4 +58,4 @@ mod validation;
 // Re-export all public types
 pub use builder::SearchQuery;
 pub use date::PubDate;
-pub use filters::{ArticleType, Language};
+pub use filters::{ArticleType, Language, SortOrder};

--- a/pubmed-client/src/pubmed/responses.rs
+++ b/pubmed-client/src/pubmed/responses.rs
@@ -23,6 +23,9 @@ pub(crate) struct ESearchData {
     /// Query key for history server
     #[serde(default, rename = "querykey")]
     pub query_key: Option<String>,
+    /// How PubMed interpreted and translated the search query
+    #[serde(default)]
+    pub querytranslation: Option<String>,
 }
 
 // EInfo API response structures

--- a/pubmed-client/tests/integration/test_search_options.rs
+++ b/pubmed-client/tests/integration/test_search_options.rs
@@ -1,0 +1,377 @@
+//! Integration tests for search sort and query translation features
+//!
+//! These tests verify that sort parameters are passed correctly to the API
+//! and that query translation is parsed from the response.
+
+use pubmed_client::pubmed::SortOrder;
+use pubmed_client::{ClientConfig, PubMedClient, SearchQuery};
+use tracing_test::traced_test;
+use wiremock::matchers::{method, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Helper: JSON response from ESearch with querytranslation
+fn esearch_json_response_with_translation(
+    pmids: &[&str],
+    total_count: usize,
+    query_translation: &str,
+) -> String {
+    let id_list: Vec<String> = pmids.iter().map(|id| format!("\"{}\"", id)).collect();
+    let escaped = query_translation.replace('"', "\\\"");
+    format!(
+        r#"{{
+            "esearchresult": {{
+                "count": "{}",
+                "retmax": "{}",
+                "retstart": "0",
+                "querytranslation": "{}",
+                "idlist": [{}]
+            }}
+        }}"#,
+        total_count,
+        pmids.len(),
+        escaped,
+        id_list.join(",")
+    )
+}
+
+/// Helper: JSON response from ESearch with history and querytranslation
+fn esearch_json_response_with_history_and_translation(
+    pmids: &[&str],
+    total_count: usize,
+    query_translation: &str,
+) -> String {
+    let id_list: Vec<String> = pmids.iter().map(|id| format!("\"{}\"", id)).collect();
+    let escaped = query_translation.replace('"', "\\\"");
+    format!(
+        r#"{{
+            "esearchresult": {{
+                "count": "{}",
+                "retmax": "{}",
+                "retstart": "0",
+                "querytranslation": "{}",
+                "webenv": "MCID_test123",
+                "querykey": "1",
+                "idlist": [{}]
+            }}
+        }}"#,
+        total_count,
+        pmids.len(),
+        escaped,
+        id_list.join(",")
+    )
+}
+
+/// Helper: create PubMedClient pointing to mock server
+fn create_test_client(base_url: &str) -> PubMedClient {
+    let config = ClientConfig::new()
+        .with_base_url(base_url)
+        .with_rate_limit(100.0)
+        .with_tool("test-client");
+    PubMedClient::with_config(config)
+}
+
+// ================================================================================================
+// Sort Order Tests
+// ================================================================================================
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_articles_with_sort_pub_date() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(query_param("sort", "pub_date"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            esearch_json_response_with_translation(&["111", "222", "333"], 3, "asthma[All Fields]"),
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = create_test_client(&mock_server.uri());
+
+    let pmids = client
+        .search_articles_with_options("asthma", 10, Some(&SortOrder::PublicationDate))
+        .await
+        .unwrap();
+
+    assert_eq!(pmids.len(), 3);
+    assert_eq!(pmids[0], "111");
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_articles_with_sort_first_author() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(query_param("sort", "Author"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            esearch_json_response_with_translation(&["444", "555"], 2, "cancer[All Fields]"),
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = create_test_client(&mock_server.uri());
+
+    let pmids = client
+        .search_articles_with_options("cancer", 10, Some(&SortOrder::FirstAuthor))
+        .await
+        .unwrap();
+
+    assert_eq!(pmids.len(), 2);
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_articles_with_sort_journal_name() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(query_param("sort", "JournalName"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            esearch_json_response_with_translation(&["666"], 1, "covid[All Fields]"),
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = create_test_client(&mock_server.uri());
+
+    let pmids = client
+        .search_articles_with_options("covid", 10, Some(&SortOrder::JournalName))
+        .await
+        .unwrap();
+
+    assert_eq!(pmids.len(), 1);
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_articles_without_sort() {
+    let mock_server = MockServer::start().await;
+
+    // When no sort is specified, the sort parameter should not be in the URL
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            esearch_json_response_with_translation(&["777"], 1, "test[All Fields]"),
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = create_test_client(&mock_server.uri());
+
+    let pmids = client
+        .search_articles_with_options("test", 10, None)
+        .await
+        .unwrap();
+
+    assert_eq!(pmids.len(), 1);
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_query_builder_with_sort() {
+    let mock_server = MockServer::start().await;
+
+    // ESearch mock (expects sort=pub_date)
+    Mock::given(method("GET"))
+        .and(query_param("sort", "pub_date"))
+        .and(query_param("db", "pubmed"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            esearch_json_response_with_translation(
+                &["123"],
+                1,
+                "\"cancer\"[MeSH Terms] OR \"cancer\"[All Fields]",
+            ),
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = create_test_client(&mock_server.uri());
+
+    let query = SearchQuery::new()
+        .query("cancer")
+        .sort(SortOrder::PublicationDate)
+        .limit(10);
+
+    let pmids = query.search(&client).await.unwrap();
+    assert_eq!(pmids.len(), 1);
+    assert_eq!(pmids[0], "123");
+}
+
+// ================================================================================================
+// Query Translation Tests
+// ================================================================================================
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_with_history_returns_query_translation() {
+    let mock_server = MockServer::start().await;
+
+    let expected_translation = "\"asthma\"[MeSH Terms] OR \"asthma\"[All Fields]";
+
+    Mock::given(method("GET"))
+        .and(query_param("usehistory", "y"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            esearch_json_response_with_history_and_translation(
+                &["111", "222"],
+                500,
+                expected_translation,
+            ),
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = create_test_client(&mock_server.uri());
+
+    let result = client.search_with_history("asthma", 10).await.unwrap();
+
+    assert_eq!(result.pmids.len(), 2);
+    assert_eq!(result.total_count, 500);
+    assert_eq!(
+        result.query_translation.as_deref(),
+        Some(expected_translation)
+    );
+    assert!(result.has_history());
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_with_history_no_query_translation() {
+    let mock_server = MockServer::start().await;
+
+    // Response without querytranslation field
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"{
+                "esearchresult": {
+                    "count": "1",
+                    "retmax": "1",
+                    "retstart": "0",
+                    "webenv": "MCID_abc",
+                    "querykey": "1",
+                    "idlist": ["999"]
+                }
+            }"#,
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = create_test_client(&mock_server.uri());
+
+    let result = client.search_with_history("test", 10).await.unwrap();
+
+    assert_eq!(result.pmids.len(), 1);
+    assert!(result.query_translation.is_none());
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_with_details_returns_query_translation_and_sort() {
+    let mock_server = MockServer::start().await;
+
+    let expected_translation = "\"cancer\"[MeSH Terms] OR \"cancer\"[All Fields]";
+
+    Mock::given(method("GET"))
+        .and(query_param("usehistory", "y"))
+        .and(query_param("sort", "pub_date"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            esearch_json_response_with_history_and_translation(
+                &["100", "200", "300"],
+                1000,
+                expected_translation,
+            ),
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = create_test_client(&mock_server.uri());
+
+    let query = SearchQuery::new()
+        .query("cancer")
+        .sort(SortOrder::PublicationDate)
+        .limit(10);
+
+    let result = query.search_with_details(&client).await.unwrap();
+
+    assert_eq!(result.pmids.len(), 3);
+    assert_eq!(result.total_count, 1000);
+    assert_eq!(
+        result.query_translation.as_deref(),
+        Some(expected_translation)
+    );
+    assert!(result.has_history());
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_with_history_and_options_sort_and_translation() {
+    let mock_server = MockServer::start().await;
+
+    let expected_translation = "\"vaccine\"[MeSH Terms] OR \"vaccine\"[All Fields]";
+
+    Mock::given(method("GET"))
+        .and(query_param("sort", "JournalName"))
+        .and(query_param("usehistory", "y"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            esearch_json_response_with_history_and_translation(
+                &["50", "51"],
+                2,
+                expected_translation,
+            ),
+        ))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = create_test_client(&mock_server.uri());
+
+    let result = client
+        .search_with_history_and_options("vaccine", 10, Some(&SortOrder::JournalName))
+        .await
+        .unwrap();
+
+    assert_eq!(result.pmids.len(), 2);
+    assert_eq!(
+        result.query_translation.as_deref(),
+        Some(expected_translation)
+    );
+}
+
+// ================================================================================================
+// Sort Order Unit Tests
+// ================================================================================================
+
+#[test]
+fn test_search_query_sort_builder() {
+    let query = SearchQuery::new()
+        .query("test")
+        .sort(SortOrder::PublicationDate);
+
+    assert_eq!(query.get_sort(), Some(&SortOrder::PublicationDate));
+    assert_eq!(query.build(), "test");
+    // Sort should not affect the query string itself
+}
+
+#[test]
+fn test_search_query_sort_override() {
+    let query = SearchQuery::new()
+        .query("test")
+        .sort(SortOrder::Relevance)
+        .sort(SortOrder::FirstAuthor);
+
+    assert_eq!(query.get_sort(), Some(&SortOrder::FirstAuthor));
+}
+
+#[test]
+fn test_search_query_no_sort_by_default() {
+    let query = SearchQuery::new().query("test");
+    assert_eq!(query.get_sort(), None);
+}

--- a/pubmed-client/tests/integration/test_webenv.rs
+++ b/pubmed-client/tests/integration/test_webenv.rs
@@ -280,6 +280,7 @@ mod unit_tests {
             total_count: 100,
             webenv: Some("MCID_abc123".to_string()),
             query_key: Some("1".to_string()),
+            query_translation: None,
         };
 
         assert!(result.has_history());
@@ -296,6 +297,7 @@ mod unit_tests {
             total_count: 100,
             webenv: None,
             query_key: Some("1".to_string()),
+            query_translation: None,
         };
 
         assert!(!result.has_history());
@@ -307,6 +309,7 @@ mod unit_tests {
             total_count: 100,
             webenv: Some("MCID_abc123".to_string()),
             query_key: None,
+            query_translation: None,
         };
 
         assert!(!result2.has_history());


### PR DESCRIPTION
## Summary

This PR adds support for sorting PubMed search results and exposes query translation information from the NCBI API. Users can now specify how results should be ordered (by publication date, author, journal name, or relevance) and see how PubMed interpreted their search query.

## Key Changes

- **Sort Order Support**: Added `SortOrder` enum with four variants (Relevance, PublicationDate, FirstAuthor, JournalName) that maps to NCBI API parameters
- **New Client Methods**: 
  - `search_articles_with_options()` - search with optional sort parameter
  - `search_and_fetch_with_options()` - fetch articles with sort support
  - `search_with_history_and_options()` - history-based search with sort support
- **SearchQuery Builder Enhancement**: Added `.sort()` method and `get_sort()` getter to the `SearchQuery` builder for fluent API usage
- **Query Translation**: Extended `SearchResult` and `ESearchData` to include `query_translation` field, capturing how PubMed interpreted the search query
- **New Method**: `SearchQuery::search_with_details()` returns `SearchResult` with query translation and history session info
- **Comprehensive Integration Tests**: Added 377 lines of integration tests covering sort parameters, query translation parsing, and various search scenarios with mocked NCBI responses
- **Language Bindings**: Updated Python (PyO3) and Node.js (NAPI) bindings to support sort order with case-insensitive string conversion
- **MCP Tool Support**: Extended the search tool to accept and apply sort order parameters

## Implementation Details

- Sort parameters are conditionally appended to API URLs only when specified
- Query translation is parsed from the `querytranslation` field in ESearch JSON responses
- The `SearchResult` struct now includes optional `query_translation` field for debugging and understanding query interpretation
- All existing methods maintain backward compatibility by defaulting sort to `None`
- Unit tests verify sort order enum behavior, API parameter mapping, and builder chaining

https://claude.ai/code/session_01TKHbff1GtikhgH7wocLW2c