### PR TITLE
Replace custom code block with Docusaurus CodeBlock component

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,5 +1,6 @@
 import type * as Preset from "@docusaurus/preset-classic"
 import type { Config } from "@docusaurus/types"
+import { themes as prismThemes } from "prism-react-renderer"
 
 const config: Config = {
   title: "pubmed-client",
@@ -30,6 +31,11 @@ const config: Config = {
   ],
 
   themeConfig: {
+    prism: {
+      theme: prismThemes.github,
+      darkTheme: prismThemes.dracula,
+      additionalLanguages: ["rust", "python", "bash"],
+    },
     colorMode: {
       defaultMode: "light",
       disableSwitch: false,

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -155,54 +155,15 @@
   border-bottom-color: var(--ifm-color-primary);
 }
 
-/* Code block */
-.codeBlock {
-  position: relative;
-  background: #1e1e2e;
+/* Code block wrapper — connects tab bar to CodeBlock with no gap */
+.codeBlockWrapper {
   border-radius: 0 0 8px 8px;
   overflow: hidden;
 }
 
-[data-theme="light"] .codeBlock {
-  background: #282c34;
-}
-
-.codePre {
-  margin: 0;
-  padding: 1.25rem 1.5rem;
-  overflow-x: auto;
-  font-size: 0.875rem;
-  line-height: 1.6;
-}
-
-.codePre code {
-  font-family: var(--ifm-font-family-monospace);
-  color: #abb2bf;
-  background: none;
-  padding: 0;
-  font-size: inherit;
-}
-
-.copyBtn {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.75rem;
-  padding: 0.25rem 0.65rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  background: rgba(255, 255, 255, 0.1);
-  color: #abb2bf;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 4px;
-  cursor: pointer;
-  transition:
-    background 0.15s,
-    color 0.15s;
-}
-
-.copyBtn:hover {
-  background: rgba(255, 255, 255, 0.18);
-  color: #fff;
+.codeBlockWrapper > div {
+  border-radius: 0 0 8px 8px;
+  margin-bottom: 0;
 }
 
 /* Packages table */

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import Link from "@docusaurus/Link"
+import CodeBlock from "@theme/CodeBlock"
 import Layout from "@theme/Layout"
 import type React from "react"
 import { useState } from "react"
@@ -48,8 +49,9 @@ const installCommands: Record<string, string> = {
   python: "pip install pubmed-client-py",
 }
 
-const quickstartCode: Record<string, string> = {
-  rust: `use pubmed_client::PubMedClient;
+const quickstartCode: Record<string, { code: string; language: string }> = {
+  rust: {
+    code: `use pubmed_client::PubMedClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -67,7 +69,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     Ok(())
 }`,
-  node: `import { PubMedClient } from "pubmed-client";
+    language: "rust",
+  },
+  node: {
+    code: `import { PubMedClient } from "pubmed-client";
 
 const client = new PubMedClient();
 const articles = await client.search("COVID-19 vaccine", 5);
@@ -75,13 +80,18 @@ const articles = await client.search("COVID-19 vaccine", 5);
 for (const article of articles) {
   console.log(article.title);
 }`,
-  python: `from pubmed_client_py import Client
+    language: "typescript",
+  },
+  python: {
+    code: `from pubmed_client_py import Client
 
 client = Client()
 articles = client.pubmed.search_and_fetch("COVID-19 vaccine", 5)
 
 for article in articles:
     print(article.title)`,
+    language: "python",
+  },
 }
 
 const docCards: DocCard[] = [
@@ -159,24 +169,13 @@ function TabBar({
   )
 }
 
-function CodeSnippet({ code }: { code: string }): React.JSX.Element {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(code).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    })
-  }
-
+function CodeSnippet({
+  code,
+  language,
+}: { code: string; language: string }): React.JSX.Element {
   return (
-    <div className={styles.codeBlock}>
-      <button type="button" className={styles.copyBtn} onClick={handleCopy}>
-        {copied ? "Copied!" : "Copy"}
-      </button>
-      <pre className={styles.codePre}>
-        <code>{code}</code>
-      </pre>
+    <div className={styles.codeBlockWrapper}>
+      <CodeBlock language={language}>{code}</CodeBlock>
     </div>
   )
 }
@@ -238,7 +237,7 @@ export default function Home(): React.JSX.Element {
             <h2>Installation</h2>
             <p className={styles.sectionIntro}>Install via your language's package manager.</p>
             <TabBar tabs={installTabs} selected={lang} onSelect={handleLangChange} />
-            <CodeSnippet code={installCommands[lang] ?? ""} />
+            <CodeSnippet code={installCommands[lang] ?? ""} language="bash" />
           </div>
         </section>
 
@@ -250,7 +249,10 @@ export default function Home(): React.JSX.Element {
               Search PubMed and fetch article metadata in a few lines.
             </p>
             <TabBar tabs={quickstartTabs} selected={quickstartLang} onSelect={handleLangChange} />
-            <CodeSnippet code={quickstartCode[quickstartLang] ?? ""} />
+            <CodeSnippet
+              code={quickstartCode[quickstartLang]?.code ?? ""}
+              language={quickstartCode[quickstartLang]?.language ?? "text"}
+            />
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
Refactored the custom code block implementation to use Docusaurus's built-in `CodeBlock` component, which provides better syntax highlighting and a native copy button. This simplifies the codebase and improves consistency with Docusaurus conventions.

## Key Changes
- **Removed custom code block styles** (`codeBlock`, `codePre`, `copyBtn`) from `index.module.css` and replaced with a minimal wrapper class (`codeBlockWrapper`) for layout purposes
- **Replaced custom `CodeSnippet` component** that manually handled code display and copy functionality with Docusaurus's `CodeBlock` component
- **Updated quickstart code structure** to include language metadata alongside code strings, enabling proper syntax highlighting for each language (Rust, TypeScript, Python)
- **Added Prism configuration** to `docusaurus.config.ts` with GitHub light theme and Dracula dark theme, plus support for Rust, Python, and Bash syntax highlighting
- **Simplified copy functionality** by delegating to Docusaurus's native copy button implementation

## Implementation Details
- The `quickstartCode` object now stores both `code` and `language` properties for each snippet
- Installation commands use `bash` language for syntax highlighting
- The `codeBlockWrapper` class maintains the rounded bottom corners and overflow handling to seamlessly connect the tab bar to the code block
- Removed approximately 50 lines of custom styling and copy button logic in favor of Docusaurus's built-in functionality

https://claude.ai/code/session_01LRm1GKQDK8ipHmYyT1bkQd