### PR TITLE
Enhance PubMed parser extraction coverage for modeled metadata

### DIFF
--- a/pubmed-parser/src/pubmed/parser/converters.rs
+++ b/pubmed-parser/src/pubmed/parser/converters.rs
@@ -80,7 +80,11 @@ impl PubmedArticleXml {
             .and_then(|p| p.medline_pgn.clone());
 
         // Extract language
-        let language = article.language.clone();
+        let language = article
+            .languages
+            .iter()
+            .find(|lang| !lang.trim().is_empty())
+            .cloned();
 
         // Extract ISO journal abbreviation
         let journal_abbreviation = article
@@ -100,8 +104,12 @@ impl PubmedArticleXml {
             .elocation_ids
             .and_then(|ids| {
                 ids.into_iter()
-                    .find(|id| id.eid_type.as_deref() == Some("doi"))
-                    .map(|id| id.value)
+                    .find(|id| {
+                        id.eid_type
+                            .as_deref()
+                            .is_some_and(|t| t.eq_ignore_ascii_case("doi"))
+                    })
+                    .map(|id| id.value.trim().to_string())
             })
             .or_else(|| Self::extract_article_id(&self.pubmed_data, "doi"));
 
@@ -118,12 +126,34 @@ impl PubmedArticleXml {
             .map_or(Vec::new(), |list| list.into_types());
 
         // Extract MeSH headings
-        let mesh_headings = medline
+        let mut mesh_headings = medline
             .mesh_heading_list
             .and_then(|list| list.into_headings());
+        let supplemental_concepts = medline
+            .suppl_mesh_list
+            .map(|list| list.into_concepts())
+            .unwrap_or_default();
+
+        if !supplemental_concepts.is_empty() {
+            match mesh_headings.as_mut() {
+                Some(headings) => {
+                    for heading in headings {
+                        heading.supplemental_concepts = supplemental_concepts.clone();
+                    }
+                }
+                None => {
+                    mesh_headings = Some(vec![MeshHeading {
+                        mesh_terms: Vec::new(),
+                        supplemental_concepts,
+                    }]);
+                }
+            }
+        }
 
         // Extract keywords
-        let keywords = medline.keyword_list.and_then(|list| list.into_keywords());
+        let keywords = medline
+            .keyword_lists
+            .and_then(|lists| KeywordList::into_keywords_from_lists(&lists));
 
         // Extract chemical list
         let chemical_list = medline.chemical_list.and_then(|list| list.into_chemicals());
@@ -346,12 +376,41 @@ impl KeywordList {
     /// Convert XML keyword list to string vector
     pub(super) fn into_keywords(self) -> Option<Vec<String>> {
         self.keywords.and_then(|keywords| {
-            let result: Vec<String> = keywords.into_iter().map(|k| k.to_string()).collect();
+            let result: Vec<String> = keywords
+                .into_iter()
+                .map(|k| k.to_string())
+                .map(|k| k.trim().to_string())
+                .filter(|k| !k.is_empty())
+                .collect();
             if result.is_empty() {
                 None
             } else {
                 Some(result)
             }
         })
+    }
+
+    /// Convert multiple keyword lists into a flattened, deduplicated vector.
+    pub(super) fn into_keywords_from_lists(lists: &[KeywordList]) -> Option<Vec<String>> {
+        let mut seen = std::collections::HashSet::new();
+        let mut flattened = Vec::new();
+
+        for list in lists {
+            if let Some(keywords) = &list.keywords {
+                for keyword in keywords {
+                    let value = keyword.to_string();
+                    let normalized = value.trim();
+                    if !normalized.is_empty() && seen.insert(normalized.to_ascii_lowercase()) {
+                        flattened.push(normalized.to_string());
+                    }
+                }
+            }
+        }
+
+        if flattened.is_empty() {
+            None
+        } else {
+            Some(flattened)
+        }
     }
 }

--- a/pubmed-parser/src/pubmed/parser/mod.rs
+++ b/pubmed-parser/src/pubmed/parser/mod.rs
@@ -912,4 +912,72 @@ mod tests {
             "Expected ArticleNotFound error for PMID 12345"
         );
     }
+
+    #[test]
+    fn test_multiple_keyword_lists_and_language_parsing() {
+        let xml = r#"<?xml version="1.0"?>
+<PubmedArticleSet>
+<PubmedArticle>
+  <MedlineCitation>
+    <PMID>99900001</PMID>
+    <Article>
+      <ArticleTitle>Keyword and language test article</ArticleTitle>
+      <Journal>
+        <Title>Test Journal</Title>
+      </Journal>
+      <Language>eng</Language>
+      <Language>fre</Language>
+    </Article>
+    <KeywordList Owner="NOTNLM">
+      <Keyword>Alpha</Keyword>
+      <Keyword>Shared</Keyword>
+    </KeywordList>
+    <KeywordList Owner="NLM">
+      <Keyword>shared</Keyword>
+      <Keyword>Beta</Keyword>
+    </KeywordList>
+  </MedlineCitation>
+</PubmedArticle>
+</PubmedArticleSet>"#;
+
+        let article = parse_article_from_xml(xml, "99900001").unwrap();
+        assert_eq!(article.language, Some("eng".to_string()));
+
+        let keywords = article.keywords.unwrap();
+        assert_eq!(keywords, vec!["Alpha", "Shared", "Beta"]);
+    }
+
+    #[test]
+    fn test_supplemental_mesh_parsing() {
+        let xml = r#"<?xml version="1.0"?>
+<PubmedArticleSet>
+<PubmedArticle>
+  <MedlineCitation>
+    <PMID>99900002</PMID>
+    <Article>
+      <ArticleTitle>Supplemental concept test article</ArticleTitle>
+      <Journal>
+        <Title>Test Journal</Title>
+      </Journal>
+    </Article>
+    <SupplMeshList>
+      <SupplMeshName Type="Disease" UI="C0007124">COVID-19</SupplMeshName>
+      <SupplMeshName Type="Protocol" UI="C0007000">Treatment Protocol</SupplMeshName>
+    </SupplMeshList>
+  </MedlineCitation>
+</PubmedArticle>
+</PubmedArticleSet>"#;
+
+        let article = parse_article_from_xml(xml, "99900002").unwrap();
+        let mesh_headings = article.mesh_headings.unwrap();
+        assert_eq!(mesh_headings.len(), 1);
+        assert_eq!(mesh_headings[0].mesh_terms.len(), 0);
+        assert_eq!(mesh_headings[0].supplemental_concepts.len(), 2);
+        assert_eq!(mesh_headings[0].supplemental_concepts[0].name, "COVID-19");
+        assert_eq!(mesh_headings[0].supplemental_concepts[0].ui, "C0007124");
+        assert_eq!(
+            mesh_headings[0].supplemental_concepts[0].concept_type,
+            Some("Disease".to_string())
+        );
+    }
 }

--- a/pubmed-parser/src/pubmed/parser/xml_types.rs
+++ b/pubmed-parser/src/pubmed/parser/xml_types.rs
@@ -7,7 +7,9 @@
 //! to match the XML element and attribute names.
 
 use super::deserializers::{deserialize_abstract_text_with_label, deserialize_bool_yn};
-use crate::pubmed::models::AbstractSection as ModelAbstractSection;
+use crate::pubmed::models::{
+    AbstractSection as ModelAbstractSection, SupplementalConcept as ModelSupplementalConcept,
+};
 use serde::{Deserialize, Deserializer};
 use std::fmt;
 use std::result;
@@ -64,7 +66,9 @@ pub(super) struct MedlineCitation {
     #[serde(rename = "ChemicalList")]
     pub chemical_list: Option<ChemicalList>,
     #[serde(rename = "KeywordList")]
-    pub keyword_list: Option<KeywordList>,
+    pub keyword_lists: Option<Vec<KeywordList>>,
+    #[serde(rename = "SupplMeshList")]
+    pub suppl_mesh_list: Option<SupplMeshList>,
 }
 
 /// PubMed ID element
@@ -94,8 +98,8 @@ pub(super) struct Article {
     pub abstract_section: Option<AbstractSection>,
     #[serde(rename = "AuthorList")]
     pub author_list: Option<AuthorList>,
-    #[serde(rename = "Language")]
-    pub language: Option<String>,
+    #[serde(rename = "Language", default)]
+    pub languages: Vec<String>,
     #[serde(rename = "PublicationTypeList")]
     pub publication_type_list: Option<PublicationTypeList>,
     #[serde(rename = "ELocationID")]
@@ -393,6 +397,46 @@ pub(super) struct NameOfSubstance {
 pub(super) struct KeywordList {
     #[serde(rename = "Keyword")]
     pub keywords: Option<Vec<KeywordElement>>,
+}
+
+/// List of supplemental MeSH concepts
+#[derive(Debug, Deserialize)]
+pub(super) struct SupplMeshList {
+    #[serde(rename = "SupplMeshName")]
+    pub concepts: Option<Vec<SupplMeshName>>,
+}
+
+/// Supplemental MeSH concept
+#[derive(Debug, Deserialize)]
+pub(super) struct SupplMeshName {
+    #[serde(rename = "$text")]
+    pub text: String,
+    #[serde(rename = "@UI")]
+    pub ui: Option<String>,
+    #[serde(rename = "@Type")]
+    pub concept_type: Option<String>,
+}
+
+impl SupplMeshList {
+    /// Convert supplemental MeSH list to public API model
+    pub(super) fn into_concepts(self) -> Vec<ModelSupplementalConcept> {
+        self.concepts
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|concept| {
+                let name = concept.text.trim();
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(ModelSupplementalConcept {
+                        name: name.to_string(),
+                        ui: concept.ui.unwrap_or_default(),
+                        concept_type: concept.concept_type,
+                    })
+                }
+            })
+            .collect()
+    }
 }
 
 /// Keyword element


### PR DESCRIPTION
## Summary
- improved PubMed XML deserialization to capture metadata that existed in domain models but was not reliably extracted
- added support for parsing multiple `<Language>` and `<KeywordList>` elements without dropping data
- added supplemental MeSH concept parsing from `<SupplMeshList>/<SupplMeshName>` and attached it to `MeshHeading.supplemental_concepts`
- made DOI extraction from `ELocationID` case-insensitive and trimmed whitespace

## What changed
### `pubmed-parser/src/pubmed/parser/xml_types.rs`
- `Article.language: Option<String>` -> `Article.languages: Vec<String>`
- `MedlineCitation.keyword_list` -> `MedlineCitation.keyword_lists: Option<Vec<KeywordList>>`
- added `MedlineCitation.suppl_mesh_list`
- added `SupplMeshList` / `SupplMeshName` XML structs and conversion helper to `SupplementalConcept`

### `pubmed-parser/src/pubmed/parser/converters.rs`
- language extraction now selects first non-empty language from `languages`
- DOI extraction from `ELocationID` now matches `EIdType="doi"` case-insensitively and trims value
- keyword extraction now flattens all keyword lists and deduplicates case-insensitively
- supplemental MeSH concepts are now propagated into parsed mesh headings
  - if a record has supplemental concepts but no descriptor headings, a placeholder heading is emitted with empty `mesh_terms` and populated `supplemental_concepts`

### `pubmed-parser/src/pubmed/parser/mod.rs`
- added parser tests for:
  - multiple language + multiple keyword-list parsing/dedup behavior
  - supplemental MeSH concept extraction

## Validation
- Formatting attempt failed in this environment because `cargo fmt` triggered a rustup channel download that could not be completed (network tunnel issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ddce7866008324bc9ea8a6de95f2bb)