### PR TITLE
add agent-lens to mise tools

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,9 @@
 [hooks]
 postinstall = ["bash ./etc/postinstall.sh"]
 
+[tools]
+"github:illumination-k/agent-lens" = { version = "rolling", prerelease = true }
+
 [env]
 # Suppress verbose Rust tool output (affects all Rust-based CLIs like cargo, dprint, etc.)
 RUST_LOG = "warn"


### PR DESCRIPTION
Integrate illumination-k/agent-lens (rolling/prerelease) so the
codebase analysis CLI is available across all MISE_ENV configs.

https://claude.ai/code/session_01NxJsQvQRoLGhJuTWicmsEY