### PR TITLE
refactor(client): centralize E-utilities URL building & request handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3460,7 +3460,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
- "urlencoding",
  "wiremock",
 ]
 

--- a/pubmed-client/Cargo.toml
+++ b/pubmed-client/Cargo.toml
@@ -30,7 +30,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = "0.3"
 tracing = { workspace = true }
-urlencoding = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "form"] }

--- a/pubmed-client/src/lib.rs
+++ b/pubmed-client/src/lib.rs
@@ -268,6 +268,7 @@ pub mod error;
 pub mod pmc;
 pub mod pubmed;
 pub mod rate_limit;
+pub(crate) mod request;
 pub mod retry;
 pub mod time;
 

--- a/pubmed-client/src/pmc/client.rs
+++ b/pubmed-client/src/pmc/client.rs
@@ -3,16 +3,16 @@ use std::time::Duration;
 use crate::cache::{PmcCache, create_cache};
 use crate::common::{PmcId, PubMedId};
 use crate::config::ClientConfig;
-use crate::error::{ParseError, PubMedError, Result};
+use crate::error::{ParseError, Result};
 use crate::pmc::extracted::ExtractedFigure;
 use crate::pmc::oa_api;
 use crate::pmc::oa_api::OaSubsetInfo;
 use crate::pmc::parser::parse_pmc_xml;
 use crate::rate_limit::RateLimiter;
-use crate::retry::with_retry;
+use crate::request::RequestExecutor;
 use pubmed_parser::pmc::PmcArticle;
-use reqwest::{Client, Response};
-use tracing::{debug, info};
+use reqwest::Client;
+use tracing::info;
 
 #[cfg(not(target_arch = "wasm32"))]
 use {crate::pmc::tar::PmcTarClient, std::path::Path};
@@ -224,33 +224,15 @@ impl PmcClient {
         let normalized_pmcid = pmc_id.as_str();
         let numeric_part = pmc_id.numeric_part();
 
-        // Build URL with API parameters
-        let mut url = format!(
-            "{}/efetch.fcgi?db=pmc&id=PMC{numeric_part}&retmode=xml",
-            self.base_url
-        );
-
-        // Add API parameters (API key, email, tool)
-        let api_params = self.config.build_api_params();
-        for (key, value) in api_params {
-            url.push('&');
-            url.push_str(&key);
-            url.push('=');
-            url.push_str(&urlencoding::encode(&value));
-        }
-
-        let response = self.make_request(&url).await?;
-
-        if !response.status().is_success() {
-            return Err(PubMedError::ApiError {
-                status: response.status().as_u16(),
-                message: response
-                    .status()
-                    .canonical_reason()
-                    .unwrap_or("Unknown error")
-                    .to_string(),
-            });
-        }
+        let id = format!("PMC{numeric_part}");
+        let response = self
+            .executor()
+            .get_endpoint(
+                &self.base_url,
+                "efetch.fcgi",
+                &[("db", "pmc"), ("id", id.as_str()), ("retmode", "xml")],
+            )
+            .await?;
 
         let xml_content = response.text().await?;
 
@@ -296,35 +278,21 @@ impl PmcClient {
     pub async fn check_pmc_availability(&self, pmid: &str) -> Result<Option<String>> {
         // Validate and parse PMID
         let pmid_obj = PubMedId::parse(pmid)?;
-        let pmid_value = pmid_obj.as_u32();
+        let pmid_value = pmid_obj.as_u32().to_string();
 
-        // Build URL with API parameters
-        let mut url = format!(
-            "{}/elink.fcgi?dbfrom=pubmed&db=pmc&id={pmid_value}&retmode=json",
-            self.base_url
-        );
-
-        // Add API parameters (API key, email, tool)
-        let api_params = self.config.build_api_params();
-        for (key, value) in api_params {
-            url.push('&');
-            url.push_str(&key);
-            url.push('=');
-            url.push_str(&urlencoding::encode(&value));
-        }
-
-        let response = self.make_request(&url).await?;
-
-        if !response.status().is_success() {
-            return Err(PubMedError::ApiError {
-                status: response.status().as_u16(),
-                message: response
-                    .status()
-                    .canonical_reason()
-                    .unwrap_or("Unknown error")
-                    .to_string(),
-            });
-        }
+        let response = self
+            .executor()
+            .get_endpoint(
+                &self.base_url,
+                "elink.fcgi",
+                &[
+                    ("dbfrom", "pubmed"),
+                    ("db", "pmc"),
+                    ("id", pmid_value.as_str()),
+                    ("retmode", "json"),
+                ],
+            )
+            .await?;
 
         let link_result: serde_json::Value = response.json().await?;
 
@@ -387,18 +355,7 @@ impl PmcClient {
     pub async fn is_oa_subset(&self, pmcid: &str) -> Result<OaSubsetInfo> {
         let url = oa_api::build_oa_api_url(pmcid)?;
 
-        let response = self.make_request(&url).await?;
-
-        if !response.status().is_success() {
-            return Err(PubMedError::ApiError {
-                status: response.status().as_u16(),
-                message: response
-                    .status()
-                    .canonical_reason()
-                    .unwrap_or("Unknown error")
-                    .to_string(),
-            });
-        }
+        let response = self.executor().get(&url).await?;
 
         let xml_content = response.text().await?;
 
@@ -563,37 +520,9 @@ impl PmcClient {
             })
     }
 
-    /// Internal helper method for making HTTP requests with retry logic
-    async fn make_request(&self, url: &str) -> Result<Response> {
-        with_retry(
-            || async {
-                self.rate_limiter.acquire().await?;
-                debug!("Making API request to: {url}");
-                let response = self
-                    .client
-                    .get(url)
-                    .send()
-                    .await
-                    .map_err(PubMedError::from)?;
-
-                // Check if response has server error status and convert to retryable error
-                if response.status().is_server_error() || response.status().as_u16() == 429 {
-                    return Err(PubMedError::ApiError {
-                        status: response.status().as_u16(),
-                        message: response
-                            .status()
-                            .canonical_reason()
-                            .unwrap_or("Unknown error")
-                            .to_string(),
-                    });
-                }
-
-                Ok(response)
-            },
-            &self.config.retry_config,
-            "NCBI API request",
-        )
-        .await
+    /// Build a request executor borrowing this client's HTTP client, rate limiter, and config.
+    fn executor(&self) -> RequestExecutor<'_> {
+        RequestExecutor::new(&self.client, &self.rate_limiter, &self.config)
     }
 }
 

--- a/pubmed-client/src/pmc/tar.rs
+++ b/pubmed-client/src/pmc/tar.rs
@@ -6,9 +6,9 @@ use crate::error::{ParseError, PubMedError, Result};
 use crate::pmc::extracted::ExtractedFigure;
 use crate::pmc::parser::parse_pmc_xml;
 use crate::rate_limit::RateLimiter;
-use crate::retry::with_retry;
+use crate::request::RequestExecutor;
 use pubmed_parser::pmc::{Figure, PmcArticle, Section};
-use reqwest::{Client, Response};
+use reqwest::Client;
 use tracing::debug;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -115,36 +115,17 @@ impl PmcTarClient {
                 message: format!("Failed to create output directory: {}", e),
             })?;
 
-        // Build OA API URL
-        let mut url = format!(
-            "https://www.ncbi.nlm.nih.gov/pmc/utils/oa/oa.fcgi?id={}&format=tgz",
-            normalized_pmcid
+        // Build OA API URL (with API parameters)
+        let url = self.executor().build_url(
+            "https://www.ncbi.nlm.nih.gov/pmc/utils/oa",
+            "oa.fcgi",
+            &[("id", normalized_pmcid.as_str()), ("format", "tgz")],
         );
-
-        // Add API parameters if available
-        let api_params = self.config.build_api_params();
-        for (key, value) in api_params {
-            url.push('&');
-            url.push_str(&key);
-            url.push('=');
-            url.push_str(&urlencoding::encode(&value));
-        }
 
         debug!("Downloading tar.gz from OA API: {}", url);
 
         // Download the OA API response
-        let response = self.make_request(&url).await?;
-
-        if !response.status().is_success() {
-            return Err(PubMedError::ApiError {
-                status: response.status().as_u16(),
-                message: response
-                    .status()
-                    .canonical_reason()
-                    .unwrap_or("Unknown error")
-                    .to_string(),
-            });
-        }
+        let response = self.executor().get(&url).await?;
 
         // Check if the response is XML (OA API response with download link)
         let content_type = response
@@ -192,18 +173,7 @@ impl PmcTarClient {
             };
 
         // Now download the actual tar.gz file
-        let tar_response = self.make_request(&download_url).await?;
-
-        if !tar_response.status().is_success() {
-            return Err(PubMedError::ApiError {
-                status: tar_response.status().as_u16(),
-                message: tar_response
-                    .status()
-                    .canonical_reason()
-                    .unwrap_or("Unknown error")
-                    .to_string(),
-            });
-        }
+        let tar_response = self.executor().get(&download_url).await?;
 
         // Create output directory if it doesn't exist
         let output_path = output_dir.as_ref();
@@ -334,32 +304,15 @@ impl PmcTarClient {
         let normalized_pmcid = pmc_id.as_str();
         let numeric_part = pmc_id.numeric_part();
 
-        // Build URL with API parameters
-        let mut url = format!(
-            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pmc&id=PMC{numeric_part}&retmode=xml"
-        );
-
-        // Add API parameters (API key, email, tool)
-        let api_params = self.config.build_api_params();
-        for (key, value) in api_params {
-            url.push('&');
-            url.push_str(&key);
-            url.push('=');
-            url.push_str(&urlencoding::encode(&value));
-        }
-
-        let response = self.make_request(&url).await?;
-
-        if !response.status().is_success() {
-            return Err(PubMedError::ApiError {
-                status: response.status().as_u16(),
-                message: response
-                    .status()
-                    .canonical_reason()
-                    .unwrap_or("Unknown error")
-                    .to_string(),
-            });
-        }
+        let id = format!("PMC{numeric_part}");
+        let response = self
+            .executor()
+            .get_endpoint(
+                self.config.effective_base_url(),
+                "efetch.fcgi",
+                &[("db", "pmc"), ("id", id.as_str()), ("retmode", "xml")],
+            )
+            .await?;
 
         let xml_content = response.text().await?;
 
@@ -642,37 +595,9 @@ impl PmcTarClient {
             })
     }
 
-    /// Internal helper method for making HTTP requests with retry logic
-    async fn make_request(&self, url: &str) -> Result<Response> {
-        with_retry(
-            || async {
-                self.rate_limiter.acquire().await?;
-                debug!("Making API request to: {url}");
-                let response = self
-                    .client
-                    .get(url)
-                    .send()
-                    .await
-                    .map_err(PubMedError::from)?;
-
-                // Check if response has server error status and convert to retryable error
-                if response.status().is_server_error() || response.status().as_u16() == 429 {
-                    return Err(PubMedError::ApiError {
-                        status: response.status().as_u16(),
-                        message: response
-                            .status()
-                            .canonical_reason()
-                            .unwrap_or("Unknown error")
-                            .to_string(),
-                    });
-                }
-
-                Ok(response)
-            },
-            &self.config.retry_config,
-            "NCBI API request",
-        )
-        .await
+    /// Build a request executor borrowing this client's HTTP client, rate limiter, and config.
+    fn executor(&self) -> RequestExecutor<'_> {
+        RequestExecutor::new(&self.client, &self.rate_limiter, &self.config)
     }
 }
 

--- a/pubmed-client/src/pubmed/client/citmatch.rs
+++ b/pubmed-client/src/pubmed/client/citmatch.rs
@@ -59,16 +59,21 @@ impl PubMedClient {
             .collect::<Vec<_>>()
             .join("%0D");
 
-        let url = format!(
-            "{}/ecitmatch.cgi?db=pubmed&retmode=xml&bdata={}",
-            self.base_url, bdata
+        // `bdata` is pre-formatted with `+`, `|`, and `%0D` separators that must
+        // reach NCBI verbatim, so it is appended raw rather than percent-encoded.
+        let mut url = self.executor().build_url(
+            &self.base_url,
+            "ecitmatch.cgi",
+            &[("db", "pubmed"), ("retmode", "xml")],
         );
+        url.push_str("&bdata=");
+        url.push_str(&bdata);
 
         debug!(
             citations_count = citations.len(),
             "Making ECitMatch API request"
         );
-        let response = self.make_request(&url).await?;
+        let response = self.executor().get(&url).await?;
         let text = response.text().await?;
 
         // Parse pipe-delimited response

--- a/pubmed-client/src/pubmed/client/egquery.rs
+++ b/pubmed-client/src/pubmed/client/egquery.rs
@@ -45,14 +45,8 @@ impl PubMedClient {
             ));
         }
 
-        let url = format!(
-            "{}/egquery.fcgi?term={}",
-            self.base_url,
-            urlencoding::encode(term)
-        );
-
         debug!(term = %term, "Making EGQuery API request");
-        let response = self.make_request(&url).await?;
+        let response = self.get_eutils("egquery.fcgi", &[("term", term)]).await?;
         let xml_text = response.text().await?;
 
         // Parse XML response using string-based extraction (consistent with existing xml_utils)

--- a/pubmed-client/src/pubmed/client/einfo.rs
+++ b/pubmed-client/src/pubmed/client/einfo.rs
@@ -34,11 +34,10 @@ impl PubMedClient {
     /// ```
     #[instrument(skip(self))]
     pub async fn get_database_list(&self) -> Result<Vec<String>> {
-        // Build URL - API parameters will be added by make_request
-        let url = format!("{}/einfo.fcgi?retmode=json", self.base_url);
-
         debug!("Making EInfo API request for database list");
-        let response = self.make_request(&url).await?;
+        let response = self
+            .get_eutils("einfo.fcgi", &[("retmode", "json")])
+            .await?;
 
         let einfo_response: EInfoResponse = response.json().await?;
 
@@ -92,15 +91,10 @@ impl PubMedClient {
             });
         }
 
-        // Build URL - API parameters will be added by make_request
-        let url = format!(
-            "{}/einfo.fcgi?db={}&retmode=json",
-            self.base_url,
-            urlencoding::encode(database)
-        );
-
         debug!("Making EInfo API request for database details");
-        let response = self.make_request(&url).await?;
+        let response = self
+            .get_eutils("einfo.fcgi", &[("db", database), ("retmode", "json")])
+            .await?;
 
         let einfo_response: EInfoResponse = response.json().await?;
 

--- a/pubmed-client/src/pubmed/client/elink.rs
+++ b/pubmed-client/src/pubmed/client/elink.rs
@@ -238,17 +238,19 @@ impl PubMedClient {
         let id_list: Vec<String> = pmids.iter().map(|id| id.to_string()).collect();
         let ids = id_list.join(",");
 
-        // Build URL - API parameters will be added by make_request
-        let url = format!(
-            "{}/elink.fcgi?dbfrom=pubmed&db={}&id={}&linkname={}&retmode=json",
-            self.base_url,
-            urlencoding::encode(target_db),
-            urlencoding::encode(&ids),
-            urlencoding::encode(link_name)
-        );
-
         debug!("Making ELink API request");
-        let response = self.make_request(&url).await?;
+        let response = self
+            .get_eutils(
+                "elink.fcgi",
+                &[
+                    ("dbfrom", "pubmed"),
+                    ("db", target_db),
+                    ("id", ids.as_str()),
+                    ("linkname", link_name),
+                    ("retmode", "json"),
+                ],
+            )
+            .await?;
 
         let elink_response: ELinkResponse = response.json().await?;
         Ok(elink_response)

--- a/pubmed-client/src/pubmed/client/espell.rs
+++ b/pubmed-client/src/pubmed/client/espell.rs
@@ -90,15 +90,10 @@ impl PubMedClient {
             });
         }
 
-        let url = format!(
-            "{}/espell.fcgi?db={}&term={}",
-            self.base_url,
-            urlencoding::encode(db),
-            urlencoding::encode(term)
-        );
-
         debug!(term = %term, db = %db, "Making ESpell API request");
-        let response = self.make_request(&url).await?;
+        let response = self
+            .get_eutils("espell.fcgi", &[("db", db), ("term", term)])
+            .await?;
         let xml_text = response.text().await?;
 
         let result = Self::parse_espell_response(&xml_text, term, db)?;

--- a/pubmed-client/src/pubmed/client/history.rs
+++ b/pubmed-client/src/pubmed/client/history.rs
@@ -6,8 +6,7 @@ use crate::pubmed::models::{EPostResult, HistorySession, PubMedArticle, SearchRe
 use crate::pubmed::parser::parse_articles_from_xml;
 use crate::pubmed::query::SortOrder;
 use crate::pubmed::responses::{EPostResponse, ESearchResult};
-use crate::retry::with_retry;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument};
 
 use super::PubMedClient;
 
@@ -129,20 +128,21 @@ impl PubMedClient {
         }
 
         // Use usehistory=y to enable history server
-        let mut url = format!(
-            "{}/esearch.fcgi?db=pubmed&term={}&retmax={}&retstart={}&retmode=json&usehistory=y",
-            self.base_url,
-            urlencoding::encode(query),
-            limit,
-            0
-        );
-
+        let limit_str = limit.to_string();
+        let mut params = vec![
+            ("db", "pubmed"),
+            ("term", query),
+            ("retmax", limit_str.as_str()),
+            ("retstart", "0"),
+            ("retmode", "json"),
+            ("usehistory", "y"),
+        ];
         if let Some(sort_order) = sort {
-            url.push_str(&format!("&sort={}", sort_order.as_api_param()));
+            params.push(("sort", sort_order.as_api_param()));
         }
 
         debug!("Making ESearch API request with history");
-        let response = self.make_request(&url).await?;
+        let response = self.get_eutils("esearch.fcgi", &params).await?;
 
         let search_result: ESearchResult = response.json().await?;
 
@@ -296,51 +296,13 @@ impl PubMedClient {
         // Append API parameters (api_key, email, tool)
         params.extend(self.config().build_api_params());
 
+        // API parameters (api_key / email / tool) are already in the form body,
+        // so the URL only needs the bare endpoint.
         let url = format!("{}/epost.fcgi", self.base_url);
 
         debug!(pmids_count = pmids.len(), "Making EPost API request");
 
-        let response = with_retry(
-            || async {
-                self.rate_limiter().acquire().await?;
-                debug!("Making POST request to: {}", url);
-                let response = self
-                    .http_client()
-                    .post(&url)
-                    .form(&params)
-                    .send()
-                    .await
-                    .map_err(PubMedError::from)?;
-
-                if response.status().is_server_error() || response.status().as_u16() == 429 {
-                    return Err(PubMedError::ApiError {
-                        status: response.status().as_u16(),
-                        message: response
-                            .status()
-                            .canonical_reason()
-                            .unwrap_or("Unknown error")
-                            .to_string(),
-                    });
-                }
-
-                Ok(response)
-            },
-            &self.config().retry_config,
-            "NCBI EPost API request",
-        )
-        .await?;
-
-        if !response.status().is_success() {
-            warn!("EPost request failed with status: {}", response.status());
-            return Err(PubMedError::ApiError {
-                status: response.status().as_u16(),
-                message: response
-                    .status()
-                    .canonical_reason()
-                    .unwrap_or("Unknown error")
-                    .to_string(),
-            });
-        }
+        let response = self.executor().post_form(&url, &params).await?;
 
         let epost_response: EPostResponse = response.json().await?;
 
@@ -424,17 +386,24 @@ impl PubMedClient {
         max: usize,
     ) -> Result<Vec<PubMedArticle>> {
         // Use WebEnv and query_key to fetch from history server
-        let url = format!(
-            "{}/efetch.fcgi?db=pubmed&query_key={}&WebEnv={}&retstart={}&retmax={}&retmode=xml&rettype=abstract",
-            self.base_url,
-            urlencoding::encode(&session.query_key),
-            urlencoding::encode(&session.webenv),
-            start,
-            max
-        );
+        let start_str = start.to_string();
+        let max_str = max.to_string();
 
         debug!("Making EFetch API request from history");
-        let response = self.make_request(&url).await?;
+        let response = self
+            .get_eutils(
+                "efetch.fcgi",
+                &[
+                    ("db", "pubmed"),
+                    ("query_key", session.query_key.as_str()),
+                    ("WebEnv", session.webenv.as_str()),
+                    ("retstart", start_str.as_str()),
+                    ("retmax", max_str.as_str()),
+                    ("retmode", "xml"),
+                    ("rettype", "abstract"),
+                ],
+            )
+            .await?;
 
         let xml_text = response.text().await?;
 

--- a/pubmed-client/src/pubmed/client/mod.rs
+++ b/pubmed-client/src/pubmed/client/mod.rs
@@ -17,7 +17,7 @@ use crate::pubmed::parser::parse_articles_from_xml;
 use crate::pubmed::query::SortOrder;
 use crate::pubmed::responses::ESearchResult;
 use crate::rate_limit::RateLimiter;
-use crate::retry::with_retry;
+use crate::request::RequestExecutor;
 use reqwest::{Client, Response};
 use tracing::{debug, info, instrument, warn};
 
@@ -161,14 +161,24 @@ impl PubMedClient {
         &self.config
     }
 
-    /// Get a reference to the rate limiter
-    pub(crate) fn rate_limiter(&self) -> &RateLimiter {
-        &self.rate_limiter
+    /// Build a request executor borrowing this client's HTTP client, rate limiter, and config.
+    pub(crate) fn executor(&self) -> RequestExecutor<'_> {
+        RequestExecutor::new(&self.client, &self.rate_limiter, &self.config)
     }
 
-    /// Get a reference to the HTTP client
-    pub(crate) fn http_client(&self) -> &Client {
-        &self.client
+    /// GET an E-utilities endpoint relative to the configured base URL.
+    ///
+    /// Builds the URL from `params` plus the API parameters (api_key / email /
+    /// tool), then performs a rate-limited, retrying request and returns a
+    /// success-checked response.
+    pub(crate) async fn get_eutils(
+        &self,
+        endpoint: &str,
+        params: &[(&str, &str)],
+    ) -> Result<Response> {
+        self.executor()
+            .get_endpoint(&self.base_url, endpoint, params)
+            .await
     }
 
     /// Fetch article metadata by PMID with full details including abstract
@@ -275,20 +285,20 @@ impl PubMedClient {
             return Ok(Vec::new());
         }
 
-        let mut url = format!(
-            "{}/esearch.fcgi?db=pubmed&term={}&retmax={}&retstart={}&retmode=json",
-            self.base_url,
-            urlencoding::encode(query),
-            limit,
-            0
-        );
-
+        let limit_str = limit.to_string();
+        let mut params = vec![
+            ("db", "pubmed"),
+            ("term", query),
+            ("retmax", limit_str.as_str()),
+            ("retstart", "0"),
+            ("retmode", "json"),
+        ];
         if let Some(sort_order) = sort {
-            url.push_str(&format!("&sort={}", sort_order.as_api_param()));
+            params.push(("sort", sort_order.as_api_param()));
         }
 
         debug!("Making initial ESearch API request");
-        let response = self.make_request(&url).await?;
+        let response = self.get_eutils("esearch.fcgi", &params).await?;
 
         let search_result: ESearchResult = response.json().await?;
 
@@ -375,13 +385,18 @@ impl PubMedClient {
                 .collect::<Vec<_>>()
                 .join(",");
 
-            let url = format!(
-                "{}/efetch.fcgi?db=pubmed&id={}&retmode=xml&rettype=abstract",
-                self.base_url, id_list
-            );
-
             debug!(batch_size = chunk.len(), "Making batch EFetch API request");
-            let response = self.make_request(&url).await?;
+            let response = self
+                .get_eutils(
+                    "efetch.fcgi",
+                    &[
+                        ("db", "pubmed"),
+                        ("id", id_list.as_str()),
+                        ("retmode", "xml"),
+                        ("rettype", "abstract"),
+                    ],
+                )
+                .await?;
             let xml_text = response.text().await?;
 
             if xml_text.trim().is_empty() {
@@ -438,72 +453,6 @@ impl PubMedClient {
 
         let pmid_refs: Vec<&str> = pmids.iter().map(|s| s.as_str()).collect();
         self.fetch_articles(&pmid_refs).await
-    }
-
-    /// Internal helper method for making HTTP requests with retry logic.
-    /// Automatically appends API parameters (api_key, email, tool) to the URL.
-    pub(crate) async fn make_request(&self, url: &str) -> Result<Response> {
-        // Build final URL with API parameters
-        let mut final_url = url.to_string();
-        let api_params = self.config.build_api_params();
-
-        if !api_params.is_empty() {
-            // Check if URL already has query parameters
-            let separator = if url.contains('?') { '&' } else { '?' };
-            final_url.push(separator);
-
-            // Append API parameters
-            let param_strings: Vec<String> = api_params
-                .into_iter()
-                .map(|(key, value)| format!("{}={}", key, urlencoding::encode(&value)))
-                .collect();
-            final_url.push_str(&param_strings.join("&"));
-        }
-
-        let response = with_retry(
-            || async {
-                self.rate_limiter.acquire().await?;
-                debug!("Making API request to: {}", final_url);
-                let response = self
-                    .client
-                    .get(&final_url)
-                    .send()
-                    .await
-                    .map_err(PubMedError::from)?;
-
-                // Check if response has server error status and convert to retryable error
-                if response.status().is_server_error() || response.status().as_u16() == 429 {
-                    return Err(PubMedError::ApiError {
-                        status: response.status().as_u16(),
-                        message: response
-                            .status()
-                            .canonical_reason()
-                            .unwrap_or("Unknown error")
-                            .to_string(),
-                    });
-                }
-
-                Ok(response)
-            },
-            &self.config.retry_config,
-            "NCBI API request",
-        )
-        .await?;
-
-        // Check for any non-success status (client errors, etc.)
-        if !response.status().is_success() {
-            warn!("API request failed with status: {}", response.status());
-            return Err(PubMedError::ApiError {
-                status: response.status().as_u16(),
-                message: response
-                    .status()
-                    .canonical_reason()
-                    .unwrap_or("Unknown error")
-                    .to_string(),
-            });
-        }
-
-        Ok(response)
     }
 }
 

--- a/pubmed-client/src/pubmed/client/summary.rs
+++ b/pubmed-client/src/pubmed/client/summary.rs
@@ -66,16 +66,20 @@ impl PubMedClient {
                 .collect::<Vec<_>>()
                 .join(",");
 
-            let url = format!(
-                "{}/esummary.fcgi?db=pubmed&id={}&retmode=json",
-                self.base_url, id_list
-            );
-
             debug!(
                 batch_size = chunk.len(),
                 "Making batch ESummary API request"
             );
-            let response = self.make_request(&url).await?;
+            let response = self
+                .get_eutils(
+                    "esummary.fcgi",
+                    &[
+                        ("db", "pubmed"),
+                        ("id", id_list.as_str()),
+                        ("retmode", "json"),
+                    ],
+                )
+                .await?;
             let json_text = response.text().await?;
 
             if json_text.trim().is_empty() {

--- a/pubmed-client/src/request.rs
+++ b/pubmed-client/src/request.rs
@@ -1,0 +1,202 @@
+//! Shared HTTP request execution for NCBI E-utilities endpoints.
+//!
+//! Every endpoint module used to hand-build its own URL with `format!`,
+//! sprinkle `urlencoding::encode()` calls, manually append the
+//! api_key / email / tool parameters, and then copy-paste the same
+//! rate-limit → retry → error-mapping block. [`RequestExecutor`] centralizes
+//! all of that so endpoints only declare their parameter set and response type.
+
+use reqwest::{Client, Response, StatusCode, Url};
+use tracing::{debug, warn};
+
+use crate::config::ClientConfig;
+use crate::error::{PubMedError, Result};
+use crate::rate_limit::RateLimiter;
+use crate::retry::with_retry;
+
+/// Bundles the pieces every endpoint needs to issue a rate-limited, retrying
+/// request against the NCBI E-utilities API.
+///
+/// It borrows from the owning client (`PubMedClient` / `PmcClient` /
+/// `PmcTarClient`), so it is cheap to construct per call.
+pub(crate) struct RequestExecutor<'a> {
+    client: &'a Client,
+    rate_limiter: &'a RateLimiter,
+    config: &'a ClientConfig,
+}
+
+impl<'a> RequestExecutor<'a> {
+    /// Create an executor borrowing the client's HTTP client, rate limiter, and config.
+    pub(crate) fn new(
+        client: &'a Client,
+        rate_limiter: &'a RateLimiter,
+        config: &'a ClientConfig,
+    ) -> Self {
+        Self {
+            client,
+            rate_limiter,
+            config,
+        }
+    }
+
+    /// Build an absolute URL from a base, an endpoint path, and query parameters.
+    ///
+    /// The endpoint-specific `params` are appended first, followed by the
+    /// configured API parameters (api_key / email / tool). All keys and values
+    /// are percent-encoded by [`Url::query_pairs_mut`], so callers never need to
+    /// call `urlencoding::encode()` themselves.
+    pub(crate) fn build_url(
+        &self,
+        base_url: &str,
+        endpoint: &str,
+        params: &[(&str, &str)],
+    ) -> String {
+        let mut url = Url::parse(&format!("{}/{}", base_url.trim_end_matches('/'), endpoint))
+            .expect("base URL and endpoint should form a valid URL");
+
+        {
+            let mut pairs = url.query_pairs_mut();
+            for (key, value) in params {
+                pairs.append_pair(key, value);
+            }
+            for (key, value) in self.config.build_api_params() {
+                pairs.append_pair(&key, &value);
+            }
+        }
+
+        url.to_string()
+    }
+
+    /// GET an endpoint, building the URL from `params` plus the API parameters.
+    pub(crate) async fn get_endpoint(
+        &self,
+        base_url: &str,
+        endpoint: &str,
+        params: &[(&str, &str)],
+    ) -> Result<Response> {
+        let url = self.build_url(base_url, endpoint, params);
+        self.get(&url).await
+    }
+
+    /// GET a pre-built URL with rate limiting, retry, and status-aware errors.
+    ///
+    /// Use this for fully-formed URLs (e.g. external OA download links or the
+    /// ECitMatch `bdata` payload that must not be re-encoded).
+    pub(crate) async fn get(&self, url: &str) -> Result<Response> {
+        debug!("Making GET request to: {url}");
+        self.send(|| self.client.get(url)).await
+    }
+
+    /// POST form-encoded data to a pre-built URL.
+    pub(crate) async fn post_form(&self, url: &str, form: &[(String, String)]) -> Result<Response> {
+        debug!("Making POST request to: {url}");
+        self.send(|| self.client.post(url).form(form)).await
+    }
+
+    /// Core request loop shared by GET and POST.
+    ///
+    /// Acquires a rate-limit token, sends a freshly-built request, retries on
+    /// transient failures (5xx / 429) with exponential backoff, and converts any
+    /// non-success status into an [`PubMedError::ApiError`] whose message
+    /// includes the HTTP status code.
+    async fn send<F>(&self, build: F) -> Result<Response>
+    where
+        F: Fn() -> reqwest::RequestBuilder,
+    {
+        let response = with_retry(
+            || async {
+                self.rate_limiter.acquire().await?;
+                let response = build().send().await.map_err(PubMedError::from)?;
+
+                // Server errors and rate limiting are retryable.
+                let status = response.status();
+                if status.is_server_error() || status.as_u16() == 429 {
+                    return Err(api_error(status));
+                }
+
+                Ok(response)
+            },
+            &self.config.retry_config,
+            "NCBI API request",
+        )
+        .await?;
+
+        // Any remaining non-success status (e.g. 4xx) is a terminal error.
+        let status = response.status();
+        if !status.is_success() {
+            warn!(status = status.as_u16(), "API request failed");
+            return Err(api_error(status));
+        }
+
+        Ok(response)
+    }
+}
+
+/// Build an [`PubMedError::ApiError`] that preserves the HTTP status code in the
+/// message (e.g. `404 Not Found`) instead of discarding it.
+fn api_error(status: StatusCode) -> PubMedError {
+    PubMedError::ApiError {
+        status: status.as_u16(),
+        message: format!(
+            "{} {}",
+            status.as_u16(),
+            status.canonical_reason().unwrap_or("Unknown error")
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn executor_config(config: &ClientConfig) -> (Client, RateLimiter) {
+        (Client::new(), config.create_rate_limiter())
+    }
+
+    #[test]
+    fn test_build_url_encodes_params_and_appends_api_params() {
+        let config = ClientConfig::new()
+            .with_api_key("KEY")
+            .with_email("user@example.com")
+            .with_tool("MyTool");
+        let (client, rate_limiter) = executor_config(&config);
+        let executor = RequestExecutor::new(&client, &rate_limiter, &config);
+
+        let url = executor.build_url(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils",
+            "esearch.fcgi",
+            &[("db", "pubmed"), ("term", "covid 19")],
+        );
+
+        assert!(url.starts_with("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?"));
+        assert!(url.contains("db=pubmed"));
+        // Space is percent/plus encoded, never left raw.
+        assert!(url.contains("term=covid+19") || url.contains("term=covid%20"));
+        assert!(url.contains("api_key=KEY"));
+        assert!(url.contains("email=user%40example.com"));
+        assert!(url.contains("tool=MyTool"));
+    }
+
+    #[test]
+    fn test_build_url_trims_trailing_slash_on_base() {
+        let config = ClientConfig::new();
+        let (client, rate_limiter) = executor_config(&config);
+        let executor = RequestExecutor::new(&client, &rate_limiter, &config);
+
+        let url = executor.build_url("http://example.com/", "einfo.fcgi", &[("retmode", "json")]);
+        assert!(url.starts_with("http://example.com/einfo.fcgi?"));
+        // Tool is always present.
+        assert!(url.contains("tool=pubmed-client"));
+    }
+
+    #[test]
+    fn test_api_error_includes_status_code() {
+        let err = api_error(StatusCode::NOT_FOUND);
+        let PubMedError::ApiError { status, message } = err else {
+            unreachable!("api_error always returns ApiError");
+        };
+        assert_eq!(status, 404);
+        assert!(message.contains("404"));
+        assert!(message.contains("Not Found"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements [refactorings/09-client-url-request-duplication.md](refactorings/09-client-url-request-duplication.md): eliminates the copy-pasted URL construction and request-handling that was scattered across 17+ sites in `pubmed-client`.

Adds `RequestExecutor<'a>` (`pubmed-client/src/request.rs`) — borrowing the owning client's `client` / `rate_limiter` / `config` — that centralizes:

- **URL building** via reqwest's `Url::query_pairs_mut()` (proper percent-encoding) + automatic `api_key`/`email`/`tool` injection. No more hand-written `format!` + scattered `urlencoding::encode()`.
- **One request pipeline**: rate-limit → retry w/ backoff → status check (`get` / `get_endpoint` / `post_form`).
- **Status-aware errors**: `ApiError` messages now include the HTTP code (e.g. `404 Not Found`) instead of discarding it.

## Changes

- Each endpoint reduced to declaring its params + response type: PubMed (`search`/`fetch`/`summary`/`einfo`/`elink`/`egquery`/`espell`/`citmatch`/`history`/`epost`) and PMC (`fetch_xml`/`check_pmc_availability`/`is_oa_subset`, tar `download`/`fetch_xml`).
- Deleted all **three** duplicated `make_request` implementations (the two PMC copies were lexically 100% identical per the agent-lens analysis) and the manual api-param push loops.
- Dropped the now-unused `urlencoding` dependency and dead `rate_limiter()`/`http_client()` accessors.
- `tar.rs::fetch_xml` now respects a custom `base_url` via `effective_base_url()` (matches `PmcClient::fetch_xml`).

Net **−233 lines** across 11 files. Public API unchanged.

### Deliberate choices
- **ECitMatch** keeps its raw `bdata` (`+`/`|`/`%0D` separators) appended verbatim — reqwest encoding would corrupt it.
- **EPost** stays a POST with API params in the form body, URL left bare — preserves prior behavior exactly.

## Testing
- `cargo nextest run -p pubmed-client` → **351 passed**
- `cargo clippy -p pubmed-client --all-targets` → clean
- `cargo check --workspace` → passes (napi/wasm/py/cli/mcp unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)