### PR TITLE
chore(lint): forbid unwrap/expect in non-test code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,13 @@ thiserror = "1.0"
 tracing = "0.1"
 urlencoding = "2.1"
 
+[workspace.lints.clippy]
+# Forbid `.unwrap()` / `.expect()` in non-test code. Tests, examples and
+# benches are exempted via `allow-unwrap-in-tests` / `allow-expect-in-tests`
+# in clippy.toml (and per-target allows where needed).
+unwrap_used = "deny"
+expect_used = "deny"
+
 [profile.bench]
 debug = true
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/pubmed-cli/Cargo.toml
+++ b/pubmed-cli/Cargo.toml
@@ -55,3 +55,6 @@ aws-smithy-mocks-experimental = "0.2"
 aws-smithy-runtime-api = "1.7"
 tempfile = "3.8"
 tokio-test = "0.4"
+
+[lints]
+workspace = true

--- a/pubmed-client-napi/Cargo.toml
+++ b/pubmed-client-napi/Cargo.toml
@@ -25,3 +25,6 @@ napi-build = "1"
 [profile.release]
 lto = true
 strip = "symbols"
+
+[lints]
+workspace = true

--- a/pubmed-client-py/Cargo.toml
+++ b/pubmed-client-py/Cargo.toml
@@ -38,3 +38,6 @@ doc = false
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/pubmed-client-py/src/utils.rs
+++ b/pubmed-client-py/src/utils.rs
@@ -11,6 +11,11 @@ use tokio::runtime::Runtime;
 // ================================================================================================
 
 /// Get or create a Tokio runtime for blocking operations
+///
+/// `Runtime::new` only fails when the OS cannot create the underlying event
+/// loop / worker threads — an unrecoverable environment error — so this helper
+/// is allowed to `expect` here.
+#[allow(clippy::expect_used)]
 pub fn get_runtime() -> Runtime {
     Runtime::new().expect("Failed to create Tokio runtime")
 }

--- a/pubmed-client-wasm/Cargo.toml
+++ b/pubmed-client-wasm/Cargo.toml
@@ -38,3 +38,6 @@ serde_json = { workspace = true }
 [features]
 default = []
 tsify = ["dep:tsify"]
+
+[lints]
+workspace = true

--- a/pubmed-client/Cargo.toml
+++ b/pubmed-client/Cargo.toml
@@ -152,3 +152,6 @@ path = "tests/integration/api/webenv.rs"
 [[test]]
 name = "mocked_epost"
 path = "tests/integration/test_epost_mocked.rs"
+
+[lints]
+workspace = true

--- a/pubmed-client/src/pmc/client.rs
+++ b/pubmed-client/src/pmc/client.rs
@@ -77,6 +77,10 @@ impl PmcClient {
         let rate_limiter = config.create_rate_limiter();
         let base_url = config.effective_base_url().to_string();
 
+        // reqwest's client builder only fails if the TLS backend cannot be
+        // initialized — an unrecoverable process-level environment error — so
+        // this infallible public constructor is allowed to `expect` here.
+        #[allow(clippy::expect_used)]
         let client = {
             #[cfg(not(target_arch = "wasm32"))]
             {

--- a/pubmed-client/src/pmc/tar.rs
+++ b/pubmed-client/src/pmc/tar.rs
@@ -33,6 +33,10 @@ impl PmcTarClient {
     pub fn new(config: ClientConfig) -> Self {
         let rate_limiter = config.create_rate_limiter();
 
+        // reqwest's client builder only fails if the TLS backend cannot be
+        // initialized — an unrecoverable process-level environment error — so
+        // this infallible public constructor is allowed to `expect` here.
+        #[allow(clippy::expect_used)]
         let client = {
             #[cfg(not(target_arch = "wasm32"))]
             {
@@ -120,7 +124,7 @@ impl PmcTarClient {
             "https://www.ncbi.nlm.nih.gov/pmc/utils/oa",
             "oa.fcgi",
             &[("id", normalized_pmcid.as_str()), ("format", "tgz")],
-        );
+        )?;
 
         debug!("Downloading tar.gz from OA API: {}", url);
 

--- a/pubmed-client/src/pubmed/client/citmatch.rs
+++ b/pubmed-client/src/pubmed/client/citmatch.rs
@@ -65,7 +65,7 @@ impl PubMedClient {
             &self.base_url,
             "ecitmatch.cgi",
             &[("db", "pubmed"), ("retmode", "xml")],
-        );
+        )?;
         url.push_str("&bdata=");
         url.push_str(&bdata);
 

--- a/pubmed-client/src/pubmed/client/mod.rs
+++ b/pubmed-client/src/pubmed/client/mod.rs
@@ -96,6 +96,10 @@ impl PubMedClient {
         let rate_limiter = config.create_rate_limiter();
         let base_url = config.effective_base_url().to_string();
 
+        // reqwest's client builder only fails if the TLS backend cannot be
+        // initialized — an unrecoverable process-level environment error — so
+        // this infallible public constructor is allowed to `expect` here.
+        #[allow(clippy::expect_used)]
         let client = {
             #[cfg(not(target_arch = "wasm32"))]
             {

--- a/pubmed-client/src/rate_limit.rs
+++ b/pubmed-client/src/rate_limit.rs
@@ -97,7 +97,10 @@ impl RateLimiter {
     #[instrument(skip(self))]
     pub async fn acquire(&self) -> crate::Result<()> {
         let should_wait = {
-            let mut bucket = self.bucket.lock().unwrap();
+            let mut bucket = self
+                .bucket
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             self.refill_bucket(&mut bucket);
 
             if bucket.tokens >= 1.0 {
@@ -122,7 +125,10 @@ impl RateLimiter {
             sleep(wait_duration).await;
 
             // After waiting, refill bucket and consume token
-            let mut bucket = self.bucket.lock().unwrap();
+            let mut bucket = self
+                .bucket
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             self.refill_bucket(&mut bucket);
             bucket.tokens = bucket.tokens.min(bucket.capacity);
             if bucket.tokens >= 1.0 {
@@ -139,21 +145,30 @@ impl RateLimiter {
     /// Returns `true` if a token is available and can be acquired immediately.
     /// This method does not consume a token.
     pub fn check_available(&self) -> bool {
-        let mut bucket = self.bucket.lock().unwrap();
+        let mut bucket = self
+            .bucket
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         self.refill_bucket(&mut bucket);
         bucket.tokens >= 1.0
     }
 
     /// Get current token count (for testing and monitoring)
     pub fn token_count(&self) -> f64 {
-        let mut bucket = self.bucket.lock().unwrap();
+        let mut bucket = self
+            .bucket
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         self.refill_bucket(&mut bucket);
         bucket.tokens
     }
 
     /// Get the configured rate limit (requests per second)
     pub fn rate(&self) -> f64 {
-        let bucket = self.bucket.lock().unwrap();
+        let bucket = self
+            .bucket
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         bucket.refill_rate
     }
 

--- a/pubmed-client/src/request.rs
+++ b/pubmed-client/src/request.rs
@@ -50,9 +50,13 @@ impl<'a> RequestExecutor<'a> {
         base_url: &str,
         endpoint: &str,
         params: &[(&str, &str)],
-    ) -> String {
+    ) -> Result<String> {
         let mut url = Url::parse(&format!("{}/{}", base_url.trim_end_matches('/'), endpoint))
-            .expect("base URL and endpoint should form a valid URL");
+            .map_err(|e| {
+                crate::PubMedError::InvalidQuery(format!(
+                    "failed to build request URL from base {base_url:?} and endpoint {endpoint:?}: {e}"
+                ))
+            })?;
 
         {
             let mut pairs = url.query_pairs_mut();
@@ -64,7 +68,7 @@ impl<'a> RequestExecutor<'a> {
             }
         }
 
-        url.to_string()
+        Ok(url.to_string())
     }
 
     /// GET an endpoint, building the URL from `params` plus the API parameters.
@@ -74,7 +78,7 @@ impl<'a> RequestExecutor<'a> {
         endpoint: &str,
         params: &[(&str, &str)],
     ) -> Result<Response> {
-        let url = self.build_url(base_url, endpoint, params);
+        let url = self.build_url(base_url, endpoint, params)?;
         self.get(&url).await
     }
 
@@ -162,11 +166,13 @@ mod tests {
         let (client, rate_limiter) = executor_config(&config);
         let executor = RequestExecutor::new(&client, &rate_limiter, &config);
 
-        let url = executor.build_url(
-            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils",
-            "esearch.fcgi",
-            &[("db", "pubmed"), ("term", "covid 19")],
-        );
+        let url = executor
+            .build_url(
+                "https://eutils.ncbi.nlm.nih.gov/entrez/eutils",
+                "esearch.fcgi",
+                &[("db", "pubmed"), ("term", "covid 19")],
+            )
+            .unwrap();
 
         assert!(url.starts_with("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?"));
         assert!(url.contains("db=pubmed"));
@@ -183,7 +189,9 @@ mod tests {
         let (client, rate_limiter) = executor_config(&config);
         let executor = RequestExecutor::new(&client, &rate_limiter, &config);
 
-        let url = executor.build_url("http://example.com/", "einfo.fcgi", &[("retmode", "json")]);
+        let url = executor
+            .build_url("http://example.com/", "einfo.fcgi", &[("retmode", "json")])
+            .unwrap();
         assert!(url.starts_with("http://example.com/einfo.fcgi?"));
         // Tool is always present.
         assert!(url.contains("tool=pubmed-client"));

--- a/pubmed-client/src/retry.rs
+++ b/pubmed-client/src/retry.rs
@@ -122,9 +122,8 @@ where
     E: RetryableError + Display,
 {
     let mut attempt = 0;
-    let mut last_error = None;
 
-    while attempt <= config.max_retries {
+    loop {
         debug!(
             operation = operation_name,
             attempt = attempt,
@@ -162,35 +161,31 @@ where
                     return Err(error);
                 }
 
-                last_error = Some(error);
-
-                if attempt < config.max_retries {
-                    let delay = config.calculate_delay(attempt);
-                    debug!(
-                        operation = operation_name,
-                        attempt = attempt + 1,
-                        max_retries = config.max_retries,
-                        delay_ms = delay.as_millis(),
-                        error = %last_error.as_ref().unwrap(),
-                        "Retryable error encountered, will retry after delay"
-                    );
-                    sleep(delay).await;
-                } else {
+                if attempt >= config.max_retries {
                     warn!(
                         operation = operation_name,
                         attempts = attempt + 1,
-                        error = %last_error.as_ref().unwrap(),
+                        error = %error,
                         "Max retries exceeded, operation failed"
                     );
+                    return Err(error);
                 }
+
+                let delay = config.calculate_delay(attempt);
+                debug!(
+                    operation = operation_name,
+                    attempt = attempt + 1,
+                    max_retries = config.max_retries,
+                    delay_ms = delay.as_millis(),
+                    error = %error,
+                    "Retryable error encountered, will retry after delay"
+                );
+                sleep(delay).await;
             }
         }
 
         attempt += 1;
     }
-
-    // This should never be reached due to the loop logic, but just in case
-    Err(last_error.unwrap())
 }
 
 #[cfg(test)]

--- a/pubmed-formatter/Cargo.toml
+++ b/pubmed-formatter/Cargo.toml
@@ -32,3 +32,6 @@ tracing-test = "0.2"
 [[test]]
 name = "mocked_markdown"
 path = "tests/integration/mocked/markdown.rs"
+
+[lints]
+workspace = true

--- a/pubmed-formatter/src/pmc/markdown.rs
+++ b/pubmed-formatter/src/pmc/markdown.rs
@@ -854,28 +854,24 @@ impl PmcMarkdownConverter {
 
     /// Clean content by removing XML tags and fixing formatting
     fn clean_content(&self, content: &str) -> String {
-        // Remove XML tags but preserve content
-        let mut cleaned = content.to_string();
+        use std::sync::OnceLock;
 
-        // Remove common XML tags while preserving content
-        cleaned = regex::Regex::new(r"<[^>]*>")
-            .unwrap()
-            .replace_all(&cleaned, "")
-            .to_string();
+        // Remove common XML tags while preserving content. The pattern is a
+        // compile-time constant; if it somehow failed to compile we fall back to
+        // the original content rather than panicking.
+        static TAG_RE: OnceLock<Option<regex::Regex>> = OnceLock::new();
+        let mut cleaned = match TAG_RE.get_or_init(|| regex::Regex::new(r"<[^>]*>").ok()) {
+            Some(re) => re.replace_all(content, "").into_owned(),
+            None => content.to_string(),
+        };
 
         // Fix HTML entities using the predefined table
         for (entity, replacement) in HTML_ENTITIES {
             cleaned = cleaned.replace(entity, replacement);
         }
 
-        // Normalize whitespace
-        cleaned = regex::Regex::new(r"\s+")
-            .unwrap()
-            .replace_all(&cleaned, " ")
-            .trim()
-            .to_string();
-
-        cleaned
+        // Normalize whitespace (collapse runs of whitespace to a single space and trim)
+        cleaned.split_whitespace().collect::<Vec<_>>().join(" ")
     }
 
     /// Create URL-safe anchor from title

--- a/pubmed-mcp/Cargo.toml
+++ b/pubmed-mcp/Cargo.toml
@@ -33,3 +33,6 @@ rmcp = { version = "0.16", features = ["client", "transport-child-process"] }
 [[bin]]
 name = "pubmed-mcp"
 path = "src/main.rs"
+
+[lints]
+workspace = true

--- a/pubmed-parser/Cargo.toml
+++ b/pubmed-parser/Cargo.toml
@@ -58,3 +58,6 @@ harness = false
 [[bench]]
 name = "pmc_parsing"
 harness = false
+
+[lints]
+workspace = true

--- a/pubmed-parser/benches/pmc_parsing.rs
+++ b/pubmed-parser/benches/pmc_parsing.rs
@@ -1,3 +1,6 @@
+// Benchmark harness — unwrap/expect are fine here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/pubmed-parser/benches/pubmed_parsing.rs
+++ b/pubmed-parser/benches/pubmed_parsing.rs
@@ -1,3 +1,6 @@
+// Benchmark harness — unwrap/expect are fine here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/pubmed-parser/examples/profile_parsing.rs
+++ b/pubmed-parser/examples/profile_parsing.rs
@@ -6,6 +6,9 @@
 //!
 //! The default mode is "all" which profiles both PMC and PubMed parsing.
 
+// Profiling/example harness — unwrap/expect are fine here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use std::fs;
 use std::hint::black_box;
 use std::path::{Path, PathBuf};

--- a/pubmed-parser/src/common/xml_utils.rs
+++ b/pubmed-parser/src/common/xml_utils.rs
@@ -36,11 +36,14 @@ pub fn strip_inline_html_tags(xml: &str) -> Cow<'_, str> {
 
     // Regex pattern to match inline HTML tags (both opening and closing)
     // Matches: <i>, </i>, <b>, </b>, <sup>, </sup>, <sub>, </sub>, <u>, </u>, <em>, </em>, <strong>, </strong>
-    static INLINE_TAG_REGEX: OnceLock<Regex> = OnceLock::new();
-    let re = INLINE_TAG_REGEX.get_or_init(|| {
-        Regex::new(r"</?(?:i|b|u|sup|sub|em|strong|italic|bold)>")
-            .expect("Failed to compile inline tag regex")
-    });
+    static INLINE_TAG_REGEX: OnceLock<Option<Regex>> = OnceLock::new();
+    let re = INLINE_TAG_REGEX
+        .get_or_init(|| Regex::new(r"</?(?:i|b|u|sup|sub|em|strong|italic|bold)>").ok());
+
+    // If the (constant) pattern somehow failed to compile, leave the input untouched.
+    let Some(re) = re else {
+        return Cow::Borrowed(xml);
+    };
 
     let cleaned = re.replace_all(xml, "");
 

--- a/pubmed-parser/src/pmc/parser/reference.rs
+++ b/pubmed-parser/src/pmc/parser/reference.rs
@@ -172,10 +172,12 @@ fn strip_comment_tags(content: &str) -> String {
     use regex::Regex;
     use std::sync::OnceLock;
 
-    static COMMENT_RE: OnceLock<Regex> = OnceLock::new();
-    let re =
-        COMMENT_RE.get_or_init(|| Regex::new(r"<comment[^>]*>.*?</comment>").expect("valid regex"));
-    re.replace_all(content, "").into_owned()
+    static COMMENT_RE: OnceLock<Option<Regex>> = OnceLock::new();
+    match COMMENT_RE.get_or_init(|| Regex::new(r"<comment[^>]*>.*?</comment>").ok()) {
+        Some(re) => re.replace_all(content, "").into_owned(),
+        // If the (constant) pattern somehow failed to compile, leave the input untouched.
+        None => content.to_string(),
+    }
 }
 
 /// Extract detailed references from ref-list or alternative reference structures

--- a/pubmed-parser/tests/integration/parsing/pmc_snapshots.rs
+++ b/pubmed-parser/tests/integration/parsing/pmc_snapshots.rs
@@ -8,6 +8,10 @@
 //! cargo insta review
 //! ```
 
+// Test helpers below run outside `#[test]` fns, so the test-only unwrap/expect
+// exemption does not apply automatically.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use pubmed_parser::pmc::parse_pmc_xml;
 use std::path::Path;
 


### PR DESCRIPTION
## Summary

Enables clippy's `unwrap_used` / `expect_used` as workspace-wide **deny** lints (tests, benches, and examples exempted) and removes the resulting violations from library code.

## Changes

**Lint configuration**
- Add `[workspace.lints.clippy]` with `unwrap_used = "deny"` / `expect_used = "deny"` to the root `Cargo.toml`
- Add `[lints] workspace = true` to every publishable crate (test-utils excluded — it is test infrastructure)
- Add `clippy.toml` with `allow-unwrap-in-tests` / `allow-expect-in-tests` so `#[test]` / `#[cfg(test)]` code is exempt automatically

**Removed violations (made panic-free)**
- `rate_limit.rs`: recover from a poisoned mutex (`unwrap_or_else(|p| p.into_inner())`) instead of `unwrap`
- `retry.rs`: restructure the `with_retry` loop, dropping `last_error` and its three `unwrap`s
- `request.rs`: make `build_url` fallible (`Result<String>`) and propagate the error (all callers are already in `Result` contexts)
- `pubmed-parser` / `pubmed-formatter`: cache constant regexes as `OnceLock<Option<Regex>>` with an identity fallback; markdown whitespace normalization now uses `split_whitespace`

**Justified exceptions (`#[allow]` with rationale)**
- reqwest `Client::builder().build()` (3 constructors) and tokio `Runtime::new()` — fail only on unrecoverable environment init (TLS backend / OS event loop); making them fallible would be a breaking change across 32+ call sites and all bindings
- Test/bench/example helper code outside `#[test]` fns

## Verification
- `mise r lint` (dprint + `cargo fmt --check` + clippy `-D warnings`) — clean
- `cargo nextest run` — 541 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)