### PR TITLE
refactor(bindings): shared Tokio runtime, typed exceptions, exhaustive error conversion

### DIFF
--- a/pubmed-client-napi/src/lib.rs
+++ b/pubmed-client-napi/src/lib.rs
@@ -491,7 +491,7 @@ impl PubMedClient {
             .pubmed
             .search_and_fetch(&query, limit, None)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(articles.into_iter().map(Article::from).collect())
     }
@@ -511,7 +511,7 @@ impl PubMedClient {
             .pubmed
             .fetch_articles(&pmid_refs)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(articles.into_iter().map(Article::from).collect())
     }
@@ -527,7 +527,7 @@ impl PubMedClient {
             .pubmed
             .fetch_article(&pmid)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(Article::from(article))
     }
@@ -547,7 +547,7 @@ impl PubMedClient {
             .pubmed
             .fetch_summaries(&pmid_refs)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(summaries.into_iter().map(Summary::from).collect())
     }
@@ -572,7 +572,7 @@ impl PubMedClient {
             .pubmed
             .search_and_fetch_summaries(&query, limit, None)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(summaries.into_iter().map(Summary::from).collect())
     }
@@ -588,7 +588,7 @@ impl PubMedClient {
             .pmc
             .fetch_full_text(&pmcid)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(FullTextArticle::from(article))
     }
@@ -609,7 +609,7 @@ impl PubMedClient {
             .pmc
             .fetch_full_text(&pmcid)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         let options = options.unwrap_or_default();
         let mut converter = PmcMarkdownConverter::new();
@@ -643,7 +643,7 @@ impl PubMedClient {
             .pmc
             .check_pmc_availability(&pmid)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))
+            .map_err(to_napi_err)
     }
 
     /// Check if a PMC article is in the OA (Open Access) subset
@@ -674,7 +674,7 @@ impl PubMedClient {
             .pmc
             .is_oa_subset(&pmcid)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(OaSubsetInfo::from(info))
     }
@@ -693,7 +693,7 @@ impl PubMedClient {
             .pubmed
             .spell_check(&term)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(SpellCheckResult::from(result))
     }
@@ -712,7 +712,7 @@ impl PubMedClient {
             .pubmed
             .spell_check_db(&term, &db)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(SpellCheckResult::from(result))
     }
@@ -730,7 +730,7 @@ impl PubMedClient {
             .pubmed
             .search_and_fetch(&query_string, limit, None)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(articles.into_iter().map(Article::from).collect())
     }
@@ -757,7 +757,7 @@ impl PubMedClient {
             .pubmed
             .epost(&pmid_refs)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(EPostResult::from(result))
     }
@@ -784,14 +784,37 @@ impl PubMedClient {
             .pubmed
             .fetch_all_by_pmids(&pmid_refs)
             .await
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(articles.into_iter().map(Article::from).collect())
     }
 }
 
 // ================================================================================================
-// Helper Functions (thin wrappers that convert core errors to napi::Error)
+// Error Conversion
+// ================================================================================================
+
+/// Convert `PubMedError` to `napi::Error` with an exhaustive match.
+///
+/// No wildcard arm — adding a new variant to `PubMedError` will cause a
+/// compile error here, forcing an explicit mapping decision.
+fn to_napi_err(err: pubmed_client::error::PubMedError) -> Error {
+    use pubmed_client::error::PubMedError;
+    let reason = match err {
+        PubMedError::ParseError(_) => err.to_string(),
+        PubMedError::RequestError(_) => err.to_string(),
+        PubMedError::InvalidQuery(_) => err.to_string(),
+        PubMedError::RateLimitExceeded => err.to_string(),
+        PubMedError::ApiError { .. } => err.to_string(),
+        PubMedError::SearchLimitExceeded { .. } => err.to_string(),
+        PubMedError::HistorySessionError(_) => err.to_string(),
+        PubMedError::WebEnvNotAvailable => err.to_string(),
+    };
+    Error::from_reason(reason)
+}
+
+// ================================================================================================
+// Helper Functions
 // ================================================================================================
 
 fn validate_year(year: u32) -> Result<()> {

--- a/pubmed-client-py/Cargo.toml
+++ b/pubmed-client-py/Cargo.toml
@@ -22,6 +22,8 @@ pubmed-client = { workspace = true }
 pyo3 = { version = "0.28.2", features = ["extension-module"] }
 
 # pyo3-stub-gen for automatic type stub generation
+# These must stay compatible with the pyo3 version above.
+# pyo3-stub-gen 0.19.x targets pyo3 0.28.x; update them together.
 pyo3-stub-gen = "0.19"
 pyo3-stub-gen-derive = "0.19"
 

--- a/pubmed-client-py/src/lib.rs
+++ b/pubmed-client-py/src/lib.rs
@@ -92,6 +92,34 @@ fn pubmed_client(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Add query builder
     m.add_class::<PySearchQuery>()?;
 
+    // Add exception hierarchy
+    m.add(
+        "PubMedException",
+        m.py().get_type::<utils::PubMedException>(),
+    )?;
+    m.add("ParseException", m.py().get_type::<utils::ParseException>())?;
+    m.add(
+        "RequestException",
+        m.py().get_type::<utils::RequestException>(),
+    )?;
+    m.add(
+        "InvalidQueryException",
+        m.py().get_type::<utils::InvalidQueryException>(),
+    )?;
+    m.add(
+        "RateLimitException",
+        m.py().get_type::<utils::RateLimitException>(),
+    )?;
+    m.add("ApiException", m.py().get_type::<utils::ApiException>())?;
+    m.add(
+        "SearchLimitException",
+        m.py().get_type::<utils::SearchLimitException>(),
+    )?;
+    m.add(
+        "HistorySessionException",
+        m.py().get_type::<utils::HistorySessionException>(),
+    )?;
+
     Ok(())
 }
 

--- a/pubmed-client-py/src/utils.rs
+++ b/pubmed-client-py/src/utils.rs
@@ -4,27 +4,113 @@
 
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
+use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
 // ================================================================================================
 // Runtime Management
 // ================================================================================================
 
-/// Get or create a Tokio runtime for blocking operations
+static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+
+/// Get or create a shared Tokio runtime for blocking operations
 ///
-/// `Runtime::new` only fails when the OS cannot create the underlying event
-/// loop / worker threads — an unrecoverable environment error — so this helper
-/// is allowed to `expect` here.
+/// Uses a process-wide singleton so the runtime (and its worker thread pool)
+/// is created once and reused across all method calls. This avoids per-call
+/// overhead and allows connection pools and rate limiters to persist.
 #[allow(clippy::expect_used)]
-pub fn get_runtime() -> Runtime {
-    Runtime::new().expect("Failed to create Tokio runtime")
+pub fn get_runtime() -> &'static Runtime {
+    RUNTIME.get_or_init(|| Runtime::new().expect("Failed to create Tokio runtime"))
 }
 
 // ================================================================================================
-// Error Handling
+// Exception Hierarchy
 // ================================================================================================
 
-/// Convert Rust errors to Python exceptions
+pyo3::create_exception!(
+    pubmed_client,
+    PubMedException,
+    PyException,
+    "Base exception for all PubMed client errors."
+);
+pyo3::create_exception!(
+    pubmed_client,
+    ParseException,
+    PubMedException,
+    "XML or JSON parsing failed."
+);
+pyo3::create_exception!(
+    pubmed_client,
+    RequestException,
+    PubMedException,
+    "HTTP request failed (network, timeout, DNS)."
+);
+pyo3::create_exception!(
+    pubmed_client,
+    InvalidQueryException,
+    PubMedException,
+    "Invalid query structure or parameters."
+);
+pyo3::create_exception!(
+    pubmed_client,
+    RateLimitException,
+    PubMedException,
+    "API rate limit exceeded (HTTP 429)."
+);
+pyo3::create_exception!(
+    pubmed_client,
+    ApiException,
+    PubMedException,
+    "API returned an error HTTP status code."
+);
+pyo3::create_exception!(
+    pubmed_client,
+    SearchLimitException,
+    PubMedException,
+    "Requested result count exceeds the maximum retrievable limit."
+);
+pyo3::create_exception!(
+    pubmed_client,
+    HistorySessionException,
+    PubMedException,
+    "History server session expired or WebEnv unavailable."
+);
+
+// ================================================================================================
+// Error Conversion
+// ================================================================================================
+
+/// Convert a `PubMedError` into the appropriate typed Python exception.
+///
+/// The match is exhaustive (no wildcard arm) so that adding a new variant to
+/// `PubMedError` produces a compile error here, forcing an explicit mapping.
 pub fn to_py_err(err: ::pubmed_client::error::PubMedError) -> PyErr {
-    PyErr::new::<PyException, _>(format!("{}", err))
+    use ::pubmed_client::error::PubMedError;
+    match err {
+        PubMedError::ParseError(ref e) => PyErr::new::<ParseException, _>(e.to_string()),
+        PubMedError::RequestError(ref e) => {
+            PyErr::new::<RequestException, _>(format!("HTTP request failed: {e}"))
+        }
+        PubMedError::InvalidQuery(ref msg) => {
+            PyErr::new::<InvalidQueryException, _>(format!("Invalid query: {msg}"))
+        }
+        PubMedError::RateLimitExceeded => {
+            PyErr::new::<RateLimitException, _>("API rate limit exceeded")
+        }
+        PubMedError::ApiError {
+            status,
+            ref message,
+        } => PyErr::new::<ApiException, _>(format!("API error {status}: {message}")),
+        PubMedError::SearchLimitExceeded { requested, maximum } => {
+            PyErr::new::<SearchLimitException, _>(format!(
+                "Search limit exceeded: requested {requested}, maximum is {maximum}"
+            ))
+        }
+        PubMedError::HistorySessionError(ref msg) => PyErr::new::<HistorySessionException, _>(
+            format!("History session expired or invalid: {msg}"),
+        ),
+        PubMedError::WebEnvNotAvailable => {
+            PyErr::new::<HistorySessionException, _>("WebEnv not available in search result")
+        }
+    }
 }

--- a/pubmed-client-wasm/src/lib.rs
+++ b/pubmed-client-wasm/src/lib.rs
@@ -111,6 +111,36 @@ impl From<WasmClientConfig> for ClientConfig {
     }
 }
 
+// ================================================================================================
+// Error Conversion
+// ================================================================================================
+
+/// Convert `PubMedError` to a `JsValue` carrying a proper `js_sys::Error` with a
+/// `type` property that consumers can switch on (`"ParseError"`, `"RateLimitExceeded"`, etc.).
+///
+/// The match is exhaustive — adding a new `PubMedError` variant will fail to compile
+/// until an explicit mapping is added here.
+fn to_js_err(err: pubmed_client::error::PubMedError) -> JsValue {
+    use pubmed_client::error::PubMedError;
+    let (error_type, message) = match &err {
+        PubMedError::ParseError(_) => ("ParseError", err.to_string()),
+        PubMedError::RequestError(_) => ("RequestError", err.to_string()),
+        PubMedError::InvalidQuery(_) => ("InvalidQuery", err.to_string()),
+        PubMedError::RateLimitExceeded => ("RateLimitExceeded", err.to_string()),
+        PubMedError::ApiError { .. } => ("ApiError", err.to_string()),
+        PubMedError::SearchLimitExceeded { .. } => ("SearchLimitExceeded", err.to_string()),
+        PubMedError::HistorySessionError(_) => ("HistorySessionError", err.to_string()),
+        PubMedError::WebEnvNotAvailable => ("WebEnvNotAvailable", err.to_string()),
+    };
+    let js_error = js_sys::Error::new(&message);
+    let _ = js_sys::Reflect::set(
+        &js_error,
+        &JsValue::from_str("type"),
+        &JsValue::from_str(error_type),
+    );
+    js_error.into()
+}
+
 /// JavaScript-friendly wrapper for the PubMed client
 #[wasm_bindgen]
 pub struct WasmPubMedClient {
@@ -170,7 +200,7 @@ impl WasmPubMedClient {
                         articles.into_iter().map(JsArticle::from).collect();
                     Ok(serde_wasm_bindgen::to_value(&js_articles)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Search failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -189,7 +219,7 @@ impl WasmPubMedClient {
                         articles.into_iter().map(JsArticle::from).collect();
                     Ok(serde_wasm_bindgen::to_value(&js_articles)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Batch fetch failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -204,7 +234,7 @@ impl WasmPubMedClient {
                     let js_article = JsArticle::from(article);
                     Ok(serde_wasm_bindgen::to_value(&js_article)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Fetch failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -221,7 +251,7 @@ impl WasmPubMedClient {
                         summaries.into_iter().map(JsSummary::from).collect();
                     Ok(serde_wasm_bindgen::to_value(&js_summaries)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Fetch summaries failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -241,7 +271,7 @@ impl WasmPubMedClient {
                         summaries.into_iter().map(JsSummary::from).collect();
                     Ok(serde_wasm_bindgen::to_value(&js_summaries)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Search summaries failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -256,7 +286,7 @@ impl WasmPubMedClient {
                     let js_full_text = JsFullText::from(full_text);
                     Ok(serde_wasm_bindgen::to_value(&js_full_text)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Full text fetch failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -268,7 +298,7 @@ impl WasmPubMedClient {
         future_to_promise(async move {
             match client.pmc.check_pmc_availability(&pmid).await {
                 Ok(pmcid_opt) => Ok(serde_wasm_bindgen::to_value(&pmcid_opt)?),
-                Err(e) => Err(JsValue::from_str(&format!("PMC check failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -280,9 +310,7 @@ impl WasmPubMedClient {
         future_to_promise(async move {
             match client.get_related_articles(&pmids).await {
                 Ok(related) => Ok(serde_wasm_bindgen::to_value(&related)?),
-                Err(e) => Err(JsValue::from_str(&format!(
-                    "Related articles fetch failed: {e}"
-                ))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -316,7 +344,7 @@ impl WasmPubMedClient {
                         results.matches.iter().map(JsCitationMatch::from).collect();
                     Ok(serde_wasm_bindgen::to_value(&js_results)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Citation match failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
     }
@@ -330,7 +358,7 @@ impl WasmPubMedClient {
                     let js_results = JsGlobalQueryResults::from(results);
                     Ok(serde_wasm_bindgen::to_value(&js_results)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Global query failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
     }
@@ -350,7 +378,7 @@ impl WasmPubMedClient {
                     };
                     Ok(serde_wasm_bindgen::to_value(&js_result)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("EPost failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
     }
@@ -369,9 +397,7 @@ impl WasmPubMedClient {
                         articles.into_iter().map(JsArticle::from).collect();
                     Ok(serde_wasm_bindgen::to_value(&js_articles)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!(
-                    "fetch_all_by_pmids failed: {e}"
-                ))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -386,7 +412,7 @@ impl WasmPubMedClient {
                     let js_result = JsSpellCheckResult::from(result);
                     Ok(serde_wasm_bindgen::to_value(&js_result)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Spell check failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
     }
@@ -400,7 +426,7 @@ impl WasmPubMedClient {
                     let js_result = JsSpellCheckResult::from(result);
                     Ok(serde_wasm_bindgen::to_value(&js_result)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Spell check failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
     }
@@ -411,7 +437,7 @@ impl WasmPubMedClient {
         future_to_promise(async move {
             match client.get_citations(&pmids).await {
                 Ok(citations) => Ok(serde_wasm_bindgen::to_value(&citations)?),
-                Err(e) => Err(JsValue::from_str(&format!("Get citations failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -423,7 +449,7 @@ impl WasmPubMedClient {
         future_to_promise(async move {
             match client.get_pmc_links(&pmids).await {
                 Ok(links) => Ok(serde_wasm_bindgen::to_value(&links)?),
-                Err(e) => Err(JsValue::from_str(&format!("Get PMC links failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
     }
@@ -434,7 +460,7 @@ impl WasmPubMedClient {
         future_to_promise(async move {
             match client.get_database_list().await {
                 Ok(databases) => Ok(serde_wasm_bindgen::to_value(&databases)?),
-                Err(e) => Err(JsValue::from_str(&format!("Get database list failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()
@@ -446,7 +472,7 @@ impl WasmPubMedClient {
         future_to_promise(async move {
             match client.get_database_info(&database).await {
                 Ok(info) => Ok(serde_wasm_bindgen::to_value(&info)?),
-                Err(e) => Err(JsValue::from_str(&format!("Get database info failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
     }
@@ -461,7 +487,7 @@ impl WasmPubMedClient {
                     let bibtex = pubmed_client::export::articles_to_bibtex(&articles);
                     Ok(JsValue::from_str(&bibtex))
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Export failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
     }
@@ -476,7 +502,7 @@ impl WasmPubMedClient {
                     let ris = pubmed_client::export::articles_to_ris(&articles);
                     Ok(JsValue::from_str(&ris))
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Export failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
     }
@@ -1309,7 +1335,7 @@ impl WasmSearchQuery {
                         articles.into_iter().map(JsArticle::from).collect();
                     Ok(serde_wasm_bindgen::to_value(&js_articles)?)
                 }
-                Err(e) => Err(JsValue::from_str(&format!("Search failed: {e}"))),
+                Err(e) => Err(to_js_err(e)),
             }
         })
         .unchecked_into()


### PR DESCRIPTION
Python:
- Replace per-call Runtime::new() with a process-wide OnceLock<Runtime>
  singleton, eliminating repeated thread pool creation across 29 call sites
  and allowing connection pools / rate limiters to persist.
- Add typed exception hierarchy (PubMedException base → ParseException,
  RequestException, InvalidQueryException, RateLimitException,
  ApiException, SearchLimitException, HistorySessionException) so Python
  consumers can catch specific error types instead of generic Exception.
- Replace wildcard error conversion with exhaustive match on PubMedError
  variants — new variants will cause a compile error until mapped.

NAPI:
- Add centralized to_napi_err() with exhaustive match; replace all
  inline |e| Error::from_reason(e.to_string()) closures.

WASM:
- Add centralized to_js_err() that creates a proper js_sys::Error with
  a `type` property (e.g. "RateLimitExceeded", "ParseError") instead of
  plain JsValue strings, enabling programmatic error handling in JS.

Also documents the pyo3 / pyo3-stub-gen version coupling in Cargo.toml.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L2JqTAVZFj9UU8Nfzgwzh5