### PR TITLE
fix(parser): replace PMC parser silent fallbacks with Option types

### DIFF
--- a/examples/figure_extraction_complete.rs
+++ b/examples/figure_extraction_complete.rs
@@ -121,14 +121,16 @@ async fn process_article(
                 eprintln!("    ⚠️  Could not copy figure: {}", e);
             } else {
                 println!("    💾 Saved as: {}", new_filename);
-                println!(
-                    "    📝 Caption: {}",
-                    if extracted_figure.figure.caption.len() > 80 {
-                        format!("{}...", &extracted_figure.figure.caption[..80])
-                    } else {
-                        extracted_figure.figure.caption.clone()
-                    }
-                );
+                if let Some(caption) = &extracted_figure.figure.caption {
+                    println!(
+                        "    📝 Caption: {}",
+                        if caption.len() > 80 {
+                            format!("{}...", &caption[..80])
+                        } else {
+                            caption.clone()
+                        }
+                    );
+                }
 
                 if let Some(dimensions) = extracted_figure.dimensions {
                     println!("    📐 Dimensions: {}x{}", dimensions.0, dimensions.1);
@@ -181,14 +183,16 @@ async fn create_summary_report(
         if let Some(label) = &figure.label {
             report.push_str(&format!("   Label: {}\n", label));
         }
-        report.push_str(&format!(
-            "   Caption: {}\n",
-            if figure.caption.len() > 100 {
-                format!("{}...", &figure.caption[..100])
-            } else {
-                figure.caption.clone()
-            }
-        ));
+        if let Some(caption) = &figure.caption {
+            report.push_str(&format!(
+                "   Caption: {}\n",
+                if caption.len() > 100 {
+                    format!("{}...", &caption[..100])
+                } else {
+                    caption.clone()
+                }
+            ));
+        }
 
         if let Some(dimensions) = figure.dimensions {
             report.push_str(&format!(
@@ -215,7 +219,7 @@ struct FigureMetadata {
     pmcid: String,
     figure_id: String,
     label: Option<String>,
-    caption: String,
+    caption: Option<String>,
     alt_text: Option<String>,
     fig_type: Option<String>,
     original_file_path: String,

--- a/pubmed-cli/src/commands/figures.rs
+++ b/pubmed-cli/src/commands/figures.rs
@@ -454,7 +454,7 @@ struct FigureMetadata {
     pmcid: String,
     figureid: String,
     label: Option<String>,
-    caption: String,
+    caption: Option<String>,
 }
 
 fn categorize_failure_from_figures_error(

--- a/pubmed-cli/src/commands/metadata.rs
+++ b/pubmed-cli/src/commands/metadata.rs
@@ -296,7 +296,7 @@ async fn fetch_article_metadata(
         pmcid: full_text.pmcid().to_string(),
         pmid: full_text.pmid().as_ref().map(|p| p.to_string()),
         doi: full_text.doi().map(str::to_string),
-        title: full_text.title().to_string(),
+        title: full_text.title().unwrap_or("Untitled").to_string(),
         r#abstract: abstract_content,
         authors: full_text.authors().to_vec(),
         journal: Some(full_text.journal().clone()),

--- a/pubmed-client-napi/src/lib.rs
+++ b/pubmed-client-napi/src/lib.rs
@@ -301,11 +301,11 @@ pub struct FullTextArticle {
     /// PubMed ID if available
     pub pmid: Option<String>,
     /// Article title
-    pub title: String,
+    pub title: Option<String>,
     /// List of authors
     pub authors: Vec<Author>,
     /// Journal name
-    pub journal: String,
+    pub journal: Option<String>,
     /// Publication date
     pub pub_date: String,
     /// DOI if available

--- a/pubmed-client-py/pubmed_client.pyi
+++ b/pubmed-client-py/pubmed_client.pyi
@@ -189,7 +189,7 @@ class Figure:
 
     id: builtins.str
     label: typing.Optional[builtins.str]
-    caption: builtins.str
+    caption: typing.Optional[builtins.str]
     alt_text: typing.Optional[builtins.str]
     fig_type: typing.Optional[builtins.str]
     file_path: typing.Optional[builtins.str]
@@ -392,7 +392,7 @@ class PmcFullText:
 
     pmcid: builtins.str
     pmid: typing.Optional[builtins.str]
-    title: builtins.str
+    title: typing.Optional[builtins.str]
     doi: typing.Optional[builtins.str]
     def authors(self) -> typing.Any:
         r"""
@@ -1063,5 +1063,5 @@ class Table:
 
     id: builtins.str
     label: typing.Optional[builtins.str]
-    caption: builtins.str
+    caption: typing.Optional[builtins.str]
     def __repr__(self) -> builtins.str: ...

--- a/pubmed-client-py/src/pmc/models.rs
+++ b/pubmed-client-py/src/pmc/models.rs
@@ -119,7 +119,7 @@ pub struct PyFigure {
     #[pyo3(get)]
     pub label: Option<String>,
     #[pyo3(get)]
-    pub caption: String,
+    pub caption: Option<String>,
     #[pyo3(get)]
     pub alt_text: Option<String>,
     #[pyo3(get)]
@@ -203,7 +203,7 @@ pub struct PyTable {
     #[pyo3(get)]
     pub label: Option<String>,
     #[pyo3(get)]
-    pub caption: String,
+    pub caption: Option<String>,
 }
 
 impl From<&pmc::Table> for PyTable {
@@ -305,7 +305,7 @@ pub struct PyPmcFullText {
     #[pyo3(get)]
     pub pmid: Option<String>,
     #[pyo3(get)]
-    pub title: String,
+    pub title: Option<String>,
     #[pyo3(get)]
     pub doi: Option<String>,
     inner: Arc<PmcArticle>,
@@ -316,7 +316,7 @@ impl From<PmcArticle> for PyPmcFullText {
         PyPmcFullText {
             pmcid: full_text.pmcid().to_string(),
             pmid: full_text.pmid().map(|p| p.to_string()),
-            title: full_text.title().to_string(),
+            title: full_text.title().map(|s| s.to_string()),
             doi: full_text.doi().map(str::to_string),
             inner: Arc::new(full_text),
         }
@@ -418,7 +418,7 @@ impl PyPmcFullText {
 
     fn __repr__(&self) -> String {
         format!(
-            "PmcFullText(pmcid='{}', title='{}')",
+            "PmcFullText(pmcid='{}', title={:?})",
             self.pmcid, self.title
         )
     }

--- a/pubmed-client-wasm/src/lib.rs
+++ b/pubmed-client-wasm/src/lib.rs
@@ -611,7 +611,7 @@ impl From<ArticleSummary> for JsSummary {
 pub struct JsFullText {
     pub pmcid: String,
     pub pmid: Option<String>,
-    pub title: String,
+    pub title: Option<String>,
     pub authors: Vec<JsAuthor>,
     pub journal: JsJournal,
     pub pub_date: String,
@@ -630,7 +630,7 @@ pub struct JsFullText {
 #[cfg_attr(feature = "tsify", derive(tsify::Tsify))]
 #[cfg_attr(feature = "tsify", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct JsFunding {
-    pub source: String,
+    pub source: Option<String>,
     pub award_id: Option<String>,
     pub statement: Option<String>,
 }
@@ -651,7 +651,7 @@ pub struct JsAuthor {
 #[cfg_attr(feature = "tsify", derive(tsify::Tsify))]
 #[cfg_attr(feature = "tsify", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct JsJournal {
-    pub title: String,
+    pub title: Option<String>,
     pub abbreviation: Option<String>,
     pub publisher: Option<String>,
     pub issn_print: Option<String>,
@@ -676,7 +676,7 @@ pub struct JsSection {
 pub struct JsFigure {
     pub id: String,
     pub label: Option<String>,
-    pub caption: String,
+    pub caption: Option<String>,
     pub graphic_href: Option<String>,
 }
 
@@ -686,7 +686,7 @@ pub struct JsFigure {
 pub struct JsTable {
     pub id: String,
     pub label: Option<String>,
-    pub caption: String,
+    pub caption: Option<String>,
     pub footnotes: Vec<String>,
 }
 

--- a/pubmed-client/src/lib.rs
+++ b/pubmed-client/src/lib.rs
@@ -66,7 +66,7 @@
 //!         // Fetch structured full text
 //!         let full_text = client.fetch_full_text(&pmcid).await?;
 //!
-//!         println!("Title: {}", full_text.title());
+//!         println!("Title: {}", full_text.title().unwrap_or("Untitled"));
 //!         println!("Sections: {}", full_text.sections().len());
 //!         println!("References: {}", full_text.references().len());
 //!     }
@@ -143,7 +143,7 @@
 //!     let figures = client.extract_figures_with_captions("PMC7906746", output_dir).await?;
 //!
 //!     for figure in figures {
-//!         println!("Figure {}: {}", figure.figure.id, figure.figure.caption);
+//!         println!("Figure {}: {:?}", figure.figure.id, figure.figure.caption);
 //!         println!("File: {}", figure.extracted_file_path);
 //!         if let Some(dimensions) = figure.dimensions {
 //!             println!("Dimensions: {}x{}", dimensions.0, dimensions.1);

--- a/pubmed-client/src/pmc/client.rs
+++ b/pubmed-client/src/pmc/client.rs
@@ -184,7 +184,7 @@ impl PmcClient {
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = PmcClient::new();
     ///     let full_text = client.fetch_full_text("PMC7906746").await?;
-    ///     println!("Title: {}", full_text.title());
+    ///     println!("Title: {}", full_text.title().unwrap_or("Untitled"));
     ///     println!("Sections: {}", full_text.sections().len());
     ///     Ok(())
     /// }
@@ -272,7 +272,7 @@ impl PmcClient {
     ///     if let Some(pmcid) = client.check_pmc_availability("33515491").await? {
     ///         println!("PMC available: {}", pmcid);
     ///         let full_text = client.fetch_full_text(&pmcid).await?;
-    ///         println!("Title: {}", full_text.title());
+    ///         println!("Title: {}", full_text.title().unwrap_or("Untitled"));
     ///     } else {
     ///         println!("PMC not available");
     ///     }
@@ -445,7 +445,7 @@ impl PmcClient {
     ///     let figures = client.extract_figures_with_captions("PMC7906746", output_dir).await?;
     ///
     ///     for figure in figures {
-    ///         println!("Figure {}: {}", figure.figure.id, figure.figure.caption);
+    ///         println!("Figure {}: {:?}", figure.figure.id, figure.figure.caption);
     ///         println!("File: {}", figure.extracted_file_path);
     ///     }
     ///     Ok(())

--- a/pubmed-client/src/pmc/tar.rs
+++ b/pubmed-client/src/pmc/tar.rs
@@ -261,7 +261,7 @@ impl PmcTarClient {
     ///     let figures = client.extract_figures_with_captions("PMC7906746", output_dir).await?;
     ///
     ///     for figure in figures {
-    ///         println!("Figure {}: {}", figure.figure.id, figure.figure.caption);
+    ///         println!("Figure {}: {:?}", figure.figure.id, figure.figure.caption);
     ///         println!("File: {}", figure.extracted_file_path);
     ///     }
     ///     Ok(())

--- a/pubmed-client/tests/integration/api/pmc.rs
+++ b/pubmed-client/tests/integration/api/pmc.rs
@@ -346,22 +346,22 @@ mod integration_tests {
 
                         if !section.figures.is_empty() {
                             let figure = &section.figures[0];
-                            assert!(!figure.caption.is_empty(), "Figure should have caption");
+                            assert!(figure.caption.is_some(), "Figure should have caption");
 
                             debug!(
                                 figure_id = %figure.id,
-                                caption_length = figure.caption.len(),
+                                caption_length = figure.caption.as_ref().map(|c| c.len()).unwrap_or(0),
                                 "Figure details"
                             );
                         }
 
                         if !section.tables.is_empty() {
                             let table = &section.tables[0];
-                            assert!(!table.caption.is_empty(), "Table should have caption");
+                            assert!(table.caption.is_some(), "Table should have caption");
 
                             debug!(
                                 table_id = %table.id,
-                                caption_length = table.caption.len(),
+                                caption_length = table.caption.as_ref().map(|c| c.len()).unwrap_or(0),
                                 "Table details"
                             );
                         }

--- a/pubmed-client/tests/integration/mocked/cache.rs
+++ b/pubmed-client/tests/integration/mocked/cache.rs
@@ -70,11 +70,11 @@ async fn test_pmc_cache_hit() {
 
     // First fetch - should hit the API
     let article1 = client.fetch_full_text("PMC1234567").await.unwrap();
-    assert_eq!(article1.title(), "Test Article Title");
+    assert_eq!(article1.title(), Some("Test Article Title"));
 
     // Second fetch - should be served from cache
     let article2 = client.fetch_full_text("PMC1234567").await.unwrap();
-    assert_eq!(article2.title(), "Test Article Title");
+    assert_eq!(article2.title(), Some("Test Article Title"));
 
     // Verify both articles are identical
     assert_eq!(article1.pmcid(), article2.pmcid());

--- a/pubmed-client/tests/integration/mocked/figures.rs
+++ b/pubmed-client/tests/integration/mocked/figures.rs
@@ -94,7 +94,7 @@ macro_rules! test_pmcid_figure_extraction {
                                 figure_index = fig_idx,
                                 figure_id = %figure.id,
                                 figure_label = ?figure.label,
-                                caption_length = figure.caption.len(),
+                                caption_length = figure.caption.as_ref().map(|c| c.len()).unwrap_or(0),
                                 fig_type = ?figure.fig_type,
                                 graphic_href = ?figure.graphic_href,
                                 "{}  Figure in section", indent
@@ -113,7 +113,7 @@ macro_rules! test_pmcid_figure_extraction {
                 // If no figures found, provide detailed debugging information
                 if figures_count == 0 {
                     info!(pmcid = %pmcid, "No figures found - debugging information:");
-                    info!(pmcid = %pmcid, title = %pmc_full_text.title(), "Article title");
+                    info!(pmcid = %pmcid, title = ?pmc_full_text.title(), "Article title");
                     info!(pmcid = %pmcid, pmid = ?pmc_full_text.pmid(), "Associated PMID");
                     info!(pmcid = %pmcid, article_type = ?pmc_full_text.article_type, "Article type");
 
@@ -164,7 +164,7 @@ macro_rules! test_pmcid_figure_extraction {
                         figure_index = i,
                         figure_id = %figure.id,
                         figure_label = ?figure.label,
-                        caption_length = figure.caption.len(),
+                        caption_length = figure.caption.as_ref().map(|c| c.len()).unwrap_or(0),
                         fig_type = ?figure.fig_type,
                         graphic_href = ?figure.graphic_href,
                         "Successfully extracted figure"
@@ -272,7 +272,7 @@ async fn test_figure_matching_functions() {
     let figure = pubmed_client::Figure {
         id: figure_id,
         label: figure_label,
-        caption: "Test figure caption".to_string(),
+        caption: Some("Test figure caption".to_string()),
         alt_text: None,
         fig_type: None,
         graphic_href: None,
@@ -304,7 +304,7 @@ async fn test_figure_matching_by_label() {
     let figure = pubmed_client::Figure {
         id: "unknown".to_string(),
         label: Some("Figure 1".to_string()),
-        caption: "Test figure caption".to_string(),
+        caption: Some("Test figure caption".to_string()),
         alt_text: None,
         fig_type: None,
         graphic_href: None,
@@ -335,7 +335,7 @@ async fn test_figure_matching_by_filename() {
     let figure = pubmed_client::Figure {
         id: "fig_unknown".to_string(),
         label: None,
-        caption: "Test figure caption".to_string(),
+        caption: Some("Test figure caption".to_string()),
         alt_text: None,
         fig_type: None,
         graphic_href: Some("specific_file".to_string()),
@@ -366,7 +366,7 @@ async fn test_figure_no_match() {
     let figure = pubmed_client::Figure {
         id: "nonexistent".to_string(),
         label: Some("Nonexistent Figure".to_string()),
-        caption: "Test figure caption".to_string(),
+        caption: Some("Test figure caption".to_string()),
         alt_text: None,
         fig_type: None,
         graphic_href: None,

--- a/pubmed-formatter/src/pmc/markdown.rs
+++ b/pubmed-formatter/src/pmc/markdown.rs
@@ -263,7 +263,8 @@ impl PmcMarkdownConverter {
             markdown.push_str("\n\n");
         } else {
             // Always include at least the title even when metadata is disabled
-            markdown.push_str(&self.format_heading(&self.clean_content(article.title()), 1));
+            let title = article.title().unwrap_or("Untitled");
+            markdown.push_str(&self.format_heading(&self.clean_content(title), 1));
             markdown.push_str("\n\n");
         }
 
@@ -297,7 +298,8 @@ impl PmcMarkdownConverter {
             markdown.push_str("\n\n");
         } else {
             // Always include at least the title even when metadata is disabled
-            markdown.push_str(&self.format_heading(&self.clean_content(article.title()), 1));
+            let title = article.title().unwrap_or("Untitled");
+            markdown.push_str(&self.format_heading(&self.clean_content(title), 1));
             markdown.push_str("\n\n");
         }
 
@@ -325,13 +327,19 @@ impl PmcMarkdownConverter {
     fn generate_yaml_frontmatter(&self, article: &PmcArticle) -> String {
         // Build metadata structure
         let metadata = ArticleMetadata {
-            title: self.clean_content(article.title()),
+            title: self.clean_content(article.title().unwrap_or("Untitled")),
             authors: article
                 .authors()
                 .iter()
                 .map(|a| self.clean_content(&a.full_name))
                 .collect(),
-            journal: self.clean_content(&article.journal().title),
+            journal: self.clean_content(
+                article
+                    .journal()
+                    .title
+                    .as_deref()
+                    .unwrap_or("Unknown Journal"),
+            ),
             journal_abbrev: article
                 .journal()
                 .abbreviation
@@ -377,7 +385,8 @@ impl PmcMarkdownConverter {
         let mut metadata = String::new();
 
         // Title
-        metadata.push_str(&self.format_heading(&self.clean_content(article.title()), 1));
+        let title = article.title().unwrap_or("Untitled");
+        metadata.push_str(&self.format_heading(&self.clean_content(title), 1));
         metadata.push('\n');
 
         // Authors
@@ -388,7 +397,11 @@ impl PmcMarkdownConverter {
         }
 
         // Journal information
-        let journal_title = &article.journal().title;
+        let journal_title = article
+            .journal()
+            .title
+            .as_deref()
+            .unwrap_or("Unknown Journal");
         metadata.push_str(&format!("\n**Journal:** {journal_title}"));
         if let Some(abbrev) = &article.journal().abbreviation {
             metadata.push_str(&format!(" ({abbrev})"));
@@ -755,7 +768,7 @@ impl PmcMarkdownConverter {
 
     /// Format funding information
     fn format_funding(&self, funding: &FundingInfo) -> String {
-        let source = &funding.source;
+        let source = funding.source.as_deref().unwrap_or("Unknown");
         let mut text = format!("- **{source}**");
 
         if let Some(award_id) = &funding.award_id {
@@ -793,8 +806,10 @@ impl PmcMarkdownConverter {
             content.push_str(&format!("**Figure {figure_id}**"));
         }
 
-        let caption = self.clean_content(&figure.caption);
-        content.push_str(&format!(": {caption}"));
+        if let Some(caption) = &figure.caption {
+            let caption = self.clean_content(caption);
+            content.push_str(&format!(": {caption}"));
+        }
 
         if let Some(alt_text) = &figure.alt_text {
             let alt_content = self.clean_content(alt_text);
@@ -815,8 +830,10 @@ impl PmcMarkdownConverter {
             content.push_str(&format!("**Figure {figure_id}**"));
         }
 
-        let caption = self.clean_content(&figure.caption);
-        content.push_str(&format!(": {caption}"));
+        if let Some(caption) = &figure.caption {
+            let caption = self.clean_content(caption);
+            content.push_str(&format!(": {caption}"));
+        }
 
         if let Some(alt_text) = &figure.alt_text {
             let alt_content = self.clean_content(alt_text);
@@ -837,8 +854,10 @@ impl PmcMarkdownConverter {
             content.push_str(&format!("**Table {table_id}**"));
         }
 
-        let caption = self.clean_content(&table.caption);
-        content.push_str(&format!(": {caption}"));
+        if let Some(caption) = &table.caption {
+            let caption = self.clean_content(caption);
+            content.push_str(&format!(": {caption}"));
+        }
 
         if !table.footnotes.is_empty() {
             content.push_str("\n\n*Footnotes:*\n");
@@ -906,7 +925,7 @@ mod tests {
             article_type: None,
             front: Front {
                 journal_meta: JournalMeta {
-                    title: "Test Journal".to_string(),
+                    title: Some("Test Journal".to_string()),
                     abbreviation: None,
                     issn_print: None,
                     issn_electronic: None,
@@ -918,7 +937,7 @@ mod tests {
                     doi: None,
                     categories: vec![],
                     title_group: TitleGroup {
-                        article_title: title.to_string(),
+                        article_title: Some(title.to_string()),
                         subtitle: None,
                     },
                     authors: vec![],
@@ -1085,7 +1104,7 @@ mod tests {
         let converter = PmcMarkdownConverter::new().with_yaml_frontmatter(true);
 
         let mut article = test_article("COVID-19: A Comprehensive Study", "PMC7890123");
-        article.front.journal_meta.title = "Nature: Medicine & Science".to_string();
+        article.front.journal_meta.title = Some("Nature: Medicine & Science".to_string());
         article.front.article_meta.authors =
             vec![Author::from_full_name("O'Brien, Michael".to_string())];
         article.front.article_meta.pub_dates = vec![PublicationDate {

--- a/pubmed-formatter/tests/integration/mocked/markdown.rs
+++ b/pubmed-formatter/tests/integration/mocked/markdown.rs
@@ -19,7 +19,7 @@ fn build_test_article(pmcid: u32, title: &str) -> pubmed_parser::pmc::PmcArticle
         article_type: None,
         front: Front {
             journal_meta: JournalMeta {
-                title: "Test Journal".to_string(),
+                title: Some("Test Journal".to_string()),
                 abbreviation: None,
                 issn_print: None,
                 issn_electronic: None,
@@ -31,7 +31,7 @@ fn build_test_article(pmcid: u32, title: &str) -> pubmed_parser::pmc::PmcArticle
                 doi: None,
                 categories: vec![],
                 title_group: TitleGroup {
-                    article_title: title.to_string(),
+                    article_title: Some(title.to_string()),
                     subtitle: None,
                 },
                 authors: vec![],
@@ -94,7 +94,9 @@ fn test_markdown_conversion_basic(#[from(markdown_test_cases)] test_cases: Vec<P
 
         // Check that title appears in markdown (use cleaned version for comparison)
         // Clean the title using regex to remove XML tags
-        let clean_title = xml_tag_regex.replace_all(article.title(), "").to_string();
+        let clean_title = xml_tag_regex
+            .replace_all(article.title().unwrap_or(""), "")
+            .to_string();
         let title_words: Vec<&str> = clean_title.split_whitespace().take(4).collect();
         let title_portion = title_words.join(" ");
         assert!(
@@ -128,11 +130,13 @@ fn test_markdown_conversion_basic(#[from(markdown_test_cases)] test_cases: Vec<P
             "Should contain journal information for {}",
             test_case.filename()
         );
-        assert!(
-            markdown.contains(&article.journal().title),
-            "Should contain journal title for {}",
-            test_case.filename()
-        );
+        if let Some(journal_title) = &article.journal().title {
+            assert!(
+                markdown.contains(journal_title),
+                "Should contain journal title for {}",
+                test_case.filename()
+            );
+        }
 
         info!(
             filename = test_case.filename(),
@@ -193,7 +197,7 @@ fn test_markdown_conversion_with_different_configs(
             let markdown = converter.convert(&article);
             if markdown.is_empty() {
                 warn!(filename = test_case.filename(), config_name = config_name,
-                      section_count = article.sections().len(), title = %article.title(),
+                      section_count = article.sections().len(), title = %article.title().unwrap_or(""),
                       "Empty markdown generated");
             }
             assert!(
@@ -219,11 +223,10 @@ fn test_markdown_conversion_with_different_configs(
                 }
                 "setext_headers" => {
                     // For level 1 headers, should contain underlines
-                    if markdown.contains(article.title()) {
+                    let title = article.title().unwrap_or("");
+                    if markdown.contains(title) {
                         let lines: Vec<&str> = markdown.lines().collect();
-                        let title_line_idx = lines
-                            .iter()
-                            .position(|&line| line.contains(article.title()));
+                        let title_line_idx = lines.iter().position(|&line| line.contains(title));
                         if let Some(idx) = title_line_idx
                             && idx + 1 < lines.len()
                         {
@@ -602,7 +605,7 @@ fn test_markdown_edge_cases() {
     special_article.front.article_meta.authors = vec![Author::from_full_name(
         "Dr. John O'Reilly & Associates".to_string(),
     )];
-    special_article.front.journal_meta.title = "Special Characters Journal".to_string();
+    special_article.front.journal_meta.title = Some("Special Characters Journal".to_string());
     special_article.front.article_meta.keywords = vec![
         "test & validation".to_string(),
         "<script>alert('xss')</script>".to_string(),

--- a/pubmed-mcp/src/tools/figures.rs
+++ b/pubmed-mcp/src/tools/figures.rs
@@ -57,7 +57,11 @@ pub async fn get_pmc_figures(
             data: None,
         })?;
 
-    let mut result = format!("Figures from: {} ({})\n\n", article.title(), pmc_id);
+    let mut result = format!(
+        "Figures from: {} ({})\n\n",
+        article.title().unwrap_or("Untitled"),
+        pmc_id
+    );
 
     let all_figures = collect_figures(article.sections());
     let all_tables = collect_tables(article.sections());
@@ -71,7 +75,9 @@ pub async fn get_pmc_figures(
             if let Some(ref label) = fig.label {
                 result.push_str(&format!("Label: {}\n", label));
             }
-            result.push_str(&format!("Caption: {}\n", fig.caption));
+            if let Some(ref caption) = fig.caption {
+                result.push_str(&format!("Caption: {}\n", caption));
+            }
             if let Some(ref graphic_href) = fig.graphic_href {
                 result.push_str(&format!("File: {}\n", graphic_href));
             }
@@ -86,7 +92,9 @@ pub async fn get_pmc_figures(
             if let Some(ref label) = table.label {
                 result.push_str(&format!("Label: {}\n", label));
             }
-            result.push_str(&format!("Caption: {}\n", table.caption));
+            if let Some(ref caption) = table.caption {
+                result.push_str(&format!("Caption: {}\n", caption));
+            }
             result.push('\n');
         }
     }

--- a/pubmed-mcp/src/tools/fulltext.rs
+++ b/pubmed-mcp/src/tools/fulltext.rs
@@ -68,7 +68,10 @@ pub async fn get_pmc_fulltext(
     let mut result = String::new();
 
     // Metadata
-    result.push_str(&format!("Title: {}\n", article.title()));
+    result.push_str(&format!(
+        "Title: {}\n",
+        article.title().unwrap_or("Untitled")
+    ));
     result.push_str(&format!("PMC ID: {}\n", article.pmcid()));
     if let Some(ref doi) = article.doi() {
         result.push_str(&format!("DOI: {}\n", doi));
@@ -85,7 +88,10 @@ pub async fn get_pmc_fulltext(
     }
 
     // Journal
-    result.push_str(&format!("Journal: {}\n", article.journal().title));
+    result.push_str(&format!(
+        "Journal: {}\n",
+        article.journal().title.as_deref().unwrap_or("Untitled")
+    ));
 
     // Sections
     let sections = if let Some(max) = params.max_sections {
@@ -110,7 +116,8 @@ pub async fn get_pmc_fulltext(
         result.push_str(&format!("\n## Figures ({})\n", all_figures.len()));
         for fig in &all_figures {
             let label = fig.label.as_deref().unwrap_or(&fig.id);
-            result.push_str(&format!("- {}: {}\n", label, fig.caption));
+            let caption = fig.caption.as_deref().unwrap_or("");
+            result.push_str(&format!("- {}: {}\n", label, caption));
         }
     }
 
@@ -120,7 +127,8 @@ pub async fn get_pmc_fulltext(
         result.push_str(&format!("\n## Tables ({})\n", all_tables.len()));
         for table in &all_tables {
             let label = table.label.as_deref().unwrap_or(&table.id);
-            result.push_str(&format!("- {}: {}\n", label, table.caption));
+            let caption = table.caption.as_deref().unwrap_or("");
+            result.push_str(&format!("- {}: {}\n", label, caption));
         }
     }
 

--- a/pubmed-mcp/src/tools/markdown.rs
+++ b/pubmed-mcp/src/tools/markdown.rs
@@ -52,7 +52,7 @@ pub async fn get_pmc_markdown(
         .with_include_figure_captions(params.include_figure_captions.unwrap_or(true));
     info!(
         pmc_id = %pmc_id,
-        title = %article.title(),
+        title = %article.title().unwrap_or("Untitled"),
         "Converting PMC article to markdown"
     );
 

--- a/pubmed-parser/src/pmc/domain.rs
+++ b/pubmed-parser/src/pmc/domain.rs
@@ -91,8 +91,9 @@ pub struct Front {
 /// and are placed on [`ArticleMeta`] accordingly.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct JournalMeta {
-    /// Journal title. From `<journal-title-group>/<journal-title>`.
-    pub title: String,
+    /// Journal title. From `<journal-title-group>/<journal-title>`. `None`
+    /// when the element is absent in the XML.
+    pub title: Option<String>,
     /// Abbreviated journal title. From `<journal-id journal-id-type="iso-abbrev">`
     /// or `<abbrev-journal-title>`.
     pub abbreviation: Option<String>,
@@ -164,8 +165,9 @@ pub struct ArticleMeta {
 /// Maps to JATS `<title-group>`.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct TitleGroup {
-    /// Article title. From `<article-title>`.
-    pub article_title: String,
+    /// Article title. From `<article-title>`. `None` when the element is
+    /// absent in the XML.
+    pub article_title: Option<String>,
     /// Article subtitle. From `<subtitle>`.
     pub subtitle: Option<String>,
 }
@@ -277,8 +279,9 @@ pub struct Figure {
     pub id: String,
     /// Figure label (e.g., "Figure 1"). From `<label>`.
     pub label: Option<String>,
-    /// Figure caption. From `<caption>/<p>`.
-    pub caption: String,
+    /// Figure caption. From `<caption>/<p>`. `None` when the XML element is
+    /// absent or could not be parsed.
+    pub caption: Option<String>,
     /// Alt text. From `<alt-text>`.
     pub alt_text: Option<String>,
     /// Figure type (e.g., "figure", "scheme", "chart"). From `<fig fig-type="...">`.
@@ -297,8 +300,9 @@ pub struct Table {
     pub id: String,
     /// Table label (e.g., "Table 1"). From `<label>`.
     pub label: Option<String>,
-    /// Table caption. From `<caption>/<p>`.
-    pub caption: String,
+    /// Table caption. From `<caption>/<p>`. `None` when the XML element is
+    /// absent or could not be parsed.
+    pub caption: Option<String>,
     /// Header rows. From `<thead>/<tr>`.
     pub head: Vec<TableRow>,
     /// Body rows. From `<tbody>/<tr>` (or direct `<tr>` if no `<tbody>`).
@@ -469,8 +473,9 @@ impl Reference {
 /// Maps to JATS `<funding-group>/<award-group>`.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct FundingInfo {
-    /// Funding source/agency. From `<funding-source>`.
-    pub source: String,
+    /// Funding source/agency. From `<funding-source>`. `None` when the element
+    /// is absent in the XML.
+    pub source: Option<String>,
     /// Grant/award ID. From `<award-id>`.
     pub award_id: Option<String>,
     /// Funding statement. From `<funding-statement>`.
@@ -577,9 +582,9 @@ impl PmcArticle {
         self.front.article_meta.doi.as_deref()
     }
 
-    /// Article title.
-    pub fn title(&self) -> &str {
-        &self.front.article_meta.title_group.article_title
+    /// Article title, if present.
+    pub fn title(&self) -> Option<&str> {
+        self.front.article_meta.title_group.article_title.as_deref()
     }
 
     /// Article subtitle, if present.

--- a/pubmed-parser/src/pmc/parser/metadata.rs
+++ b/pubmed-parser/src/pmc/parser/metadata.rs
@@ -4,6 +4,7 @@ use crate::pmc::domain::{FundingInfo, JournalMeta, SupplementaryMaterial};
 use quick_xml::Reader;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
+use tracing::warn;
 
 use super::reader_utils::{get_attr, make_reader, read_text_content, skip_element};
 use super::xml_utils::decode_xml_entities;
@@ -216,7 +217,10 @@ fn clean_text(text: String) -> Option<String> {
     if text.is_empty() { None } else { Some(text) }
 }
 
-fn read_award_group(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> (String, Option<String>) {
+fn read_award_group(
+    reader: &mut Reader<&[u8]>,
+    buf: &mut Vec<u8>,
+) -> (Option<String>, Option<String>) {
     let mut source = None;
     let mut award_id = None;
 
@@ -255,10 +259,10 @@ fn read_award_group(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> (String, O
         }
     }
 
-    (
-        source.unwrap_or_else(|| "Unknown Source".to_string()),
-        award_id,
-    )
+    if source.is_none() {
+        warn!("funding award-group missing funding-source element");
+    }
+    (source, award_id)
 }
 
 fn read_funding_group(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Vec<FundingInfo> {
@@ -512,7 +516,7 @@ fn read_supplementary_material(
     SupplementaryMaterial {
         id: id.unwrap_or(fallback_id),
         content_type,
-        title: Some(caption.unwrap_or_else(|| "No caption available".to_string())),
+        title: caption,
         description: label,
         href,
     }
@@ -523,8 +527,7 @@ fn read_supplementary_material(
 /// Returns a [`JournalMeta`] without volume/issue — those belong to the article level
 /// per the JATS DTD and are extracted separately via [`extract_volume`] / [`extract_issue`].
 pub fn extract_journal_info(content: &str) -> JournalMeta {
-    let title =
-        read_first_text(content, b"journal-title").unwrap_or_else(|| "Unknown Journal".to_string());
+    let title = read_first_text(content, b"journal-title");
     let abbreviation =
         read_first_text_matching_attr(content, b"journal-id", b"journal-id-type", "iso-abbrev");
 
@@ -612,24 +615,35 @@ pub fn extract_pub_dates(content: &str) -> Vec<PublicationDate> {
     dates
 }
 
-/// Extract publication date in YYYY-MM-DD format
-pub fn extract_pub_date(content: &str) -> String {
-    let year = read_first_text(content, b"year");
+/// Extract publication date in YYYY-MM-DD format.
+///
+/// Returns `None` when no year element is present. Non-numeric month/day
+/// values are logged and omitted rather than silently defaulted to `1`.
+pub fn extract_pub_date(content: &str) -> Option<String> {
+    let year = read_first_text(content, b"year")?;
     let month = read_first_text(content, b"month");
     let day = read_first_text(content, b"day");
 
-    match (year, month, day) {
-        (Some(year), Some(month), Some(day)) => format!(
-            "{}-{:02}-{:02}",
-            year,
-            month.parse::<u32>().unwrap_or(1),
-            day.parse::<u32>().unwrap_or(1)
-        ),
-        (Some(year), Some(month), None) => {
-            format!("{}-{:02}", year, month.parse::<u32>().unwrap_or(1))
-        }
-        (Some(year), None, _) => year,
-        _ => "Unknown Date".to_string(),
+    match (month, day) {
+        (Some(m), Some(d)) => match (m.parse::<u32>(), d.parse::<u32>()) {
+            (Ok(mv), Ok(dv)) => Some(format!("{year}-{mv:02}-{dv:02}")),
+            (Ok(mv), Err(_)) => {
+                warn!(year = %year, month = %m, day = %d, "non-numeric day value, omitting day");
+                Some(format!("{year}-{mv:02}"))
+            }
+            (Err(_), _) => {
+                warn!(year = %year, month = %m, "non-numeric month value, omitting month/day");
+                Some(year)
+            }
+        },
+        (Some(m), None) => match m.parse::<u32>() {
+            Ok(mv) => Some(format!("{year}-{mv:02}")),
+            Err(_) => {
+                warn!(year = %year, month = %m, "non-numeric month value, omitting month");
+                Some(year)
+            }
+        },
+        _ => Some(year),
     }
 }
 
@@ -805,9 +819,9 @@ pub fn extract_supplementary_materials(content: &str) -> Vec<SupplementaryMateri
     materials
 }
 
-/// Extract article title
-pub fn extract_title(content: &str) -> String {
-    read_first_text(content, b"article-title").unwrap_or_else(|| "Unknown Title".to_string())
+/// Extract article title. Returns `None` when the element is absent.
+pub fn extract_title(content: &str) -> Option<String> {
+    read_first_text(content, b"article-title")
 }
 
 /// Extract article subtitle from `<title-group>/<subtitle>`
@@ -1014,7 +1028,13 @@ mod tests {
     fn test_extract_title() {
         let content = r#"<article-title>Test Article Title</article-title>"#;
         let title = extract_title(content);
-        assert_eq!(title, "Test Article Title");
+        assert_eq!(title.as_deref(), Some("Test Article Title"));
+    }
+
+    #[test]
+    fn test_extract_title_missing() {
+        let content = r#"<body>No title here</body>"#;
+        assert_eq!(extract_title(content), None);
     }
 
     #[test]
@@ -1065,16 +1085,34 @@ mod tests {
     #[test]
     fn test_extract_pub_date() {
         let content_full = r#"<year>2023</year><month>12</month><day>25</day>"#;
-        assert_eq!(extract_pub_date(content_full), "2023-12-25");
+        assert_eq!(
+            extract_pub_date(content_full).as_deref(),
+            Some("2023-12-25")
+        );
 
         let content_year_month = r#"<year>2023</year><month>12</month>"#;
-        assert_eq!(extract_pub_date(content_year_month), "2023-12");
+        assert_eq!(
+            extract_pub_date(content_year_month).as_deref(),
+            Some("2023-12")
+        );
 
         let content_year_only = r#"<year>2023</year>"#;
-        assert_eq!(extract_pub_date(content_year_only), "2023");
+        assert_eq!(extract_pub_date(content_year_only).as_deref(), Some("2023"));
 
         let content_no_date = r#"<title>No date here</title>"#;
-        assert_eq!(extract_pub_date(content_no_date), "Unknown Date");
+        assert_eq!(extract_pub_date(content_no_date), None);
+    }
+
+    #[test]
+    fn test_extract_pub_date_non_numeric_month() {
+        let content = r#"<year>2023</year><month>Jan</month><day>15</day>"#;
+        assert_eq!(extract_pub_date(content).as_deref(), Some("2023"));
+    }
+
+    #[test]
+    fn test_extract_pub_date_non_numeric_day() {
+        let content = r#"<year>2023</year><month>12</month><day>unknown</day>"#;
+        assert_eq!(extract_pub_date(content).as_deref(), Some("2023-12"));
     }
 
     #[test]

--- a/pubmed-parser/src/pmc/parser/mod.rs
+++ b/pubmed-parser/src/pmc/parser/mod.rs
@@ -217,7 +217,7 @@ mod tests {
 
         let article = result.unwrap();
         assert_eq!(article.pmcid().as_str(), "PMC123456");
-        assert_eq!(article.title(), "Test Article Title");
+        assert_eq!(article.title(), Some("Test Article Title"));
         assert!(!article.pub_dates().is_empty());
         assert_eq!(article.pub_dates()[0].year, Some(2023));
         assert_eq!(article.pub_dates()[0].month, Some(12));
@@ -247,7 +247,7 @@ mod tests {
 
         let article = result.unwrap();
         assert_eq!(article.pmcid().as_str(), "PMC100000");
-        assert_eq!(article.title(), "Minimal Test");
+        assert_eq!(article.title(), Some("Minimal Test"));
     }
 
     // Note: Most detailed tests have been moved to the individual parser modules:

--- a/pubmed-parser/src/pmc/parser/section.rs
+++ b/pubmed-parser/src/pmc/parser/section.rs
@@ -3,6 +3,7 @@ use crate::pmc::domain::{Figure, Section, Table};
 use super::reader_utils::{get_attr, make_reader, read_text_content, skip_element};
 use quick_xml::events::Event;
 use quick_xml::name::QName;
+use tracing::warn;
 
 /// Extract all sections from PMC XML content
 pub fn extract_sections_enhanced(content: &str) -> Vec<Section> {
@@ -550,10 +551,17 @@ fn parse_figure_inner(
                 label = read_text_content(reader, b"label", buf).ok();
             }
             FigAction::ReadCaption => {
-                caption = Some(
-                    read_text_content(reader, b"caption", buf)
-                        .unwrap_or_else(|_| "No caption available".to_string()),
-                );
+                caption = match read_text_content(reader, b"caption", buf) {
+                    Ok(text) => Some(text),
+                    Err(e) => {
+                        warn!(
+                            figure_id = ?attrs.id,
+                            error = %e,
+                            "failed to parse figure caption"
+                        );
+                        None
+                    }
+                };
             }
             FigAction::ReadAltText => {
                 alt_text = read_text_content(reader, b"alt-text", buf).ok();
@@ -570,10 +578,17 @@ fn parse_figure_inner(
         }
     }
 
+    let id = match attrs.id {
+        Some(id) => id,
+        None => {
+            warn!("figure element missing id attribute");
+            format!("fig_unknown_{}", line!())
+        }
+    };
     Some(Figure {
-        id: attrs.id.unwrap_or_else(|| "fig_unknown".to_string()),
+        id,
         label,
-        caption: caption.unwrap_or_else(|| "No caption available".to_string()),
+        caption,
         alt_text,
         fig_type: attrs.fig_type,
         graphic_href: file_name,
@@ -620,10 +635,17 @@ fn parse_table_inner(
                 label = read_text_content(reader, b"label", buf).ok();
             }
             TableAction::ReadCaption => {
-                caption = Some(
-                    read_text_content(reader, b"caption", buf)
-                        .unwrap_or_else(|_| "No caption available".to_string()),
-                );
+                caption = match read_text_content(reader, b"caption", buf) {
+                    Ok(text) => Some(text),
+                    Err(e) => {
+                        warn!(
+                            table_id = ?attrs.id,
+                            error = %e,
+                            "failed to parse table caption"
+                        );
+                        None
+                    }
+                };
             }
             TableAction::ReadFootnote => {
                 if let Ok(text) = read_text_content(reader, b"table-wrap-foot", buf) {
@@ -641,10 +663,17 @@ fn parse_table_inner(
         }
     }
 
+    let id = match attrs.id {
+        Some(id) => id,
+        None => {
+            warn!("table-wrap element missing id attribute");
+            format!("table_unknown_{}", line!())
+        }
+    };
     Some(Table {
-        id: attrs.id.unwrap_or_else(|| "table_unknown".to_string()),
+        id,
         label,
-        caption: caption.unwrap_or_else(|| "No caption available".to_string()),
+        caption,
         head: Vec::new(),
         body: Vec::new(),
         footnotes,
@@ -791,7 +820,10 @@ mod tests {
         assert_eq!(figures.len(), 1);
         assert_eq!(figures[0].id, "fig1");
         assert_eq!(figures[0].label, Some("Figure 1".to_string()));
-        assert_eq!(figures[0].caption, "This is a test figure.");
+        assert_eq!(
+            figures[0].caption.as_deref(),
+            Some("This is a test figure.")
+        );
         assert_eq!(figures[0].alt_text, Some("Alternative text".to_string()));
         assert_eq!(figures[0].fig_type, Some("diagram".to_string()));
     }
@@ -815,7 +847,7 @@ mod tests {
         assert_eq!(tables.len(), 1);
         assert_eq!(tables[0].id, "table1");
         assert_eq!(tables[0].label, Some("Table 1".to_string()));
-        assert_eq!(tables[0].caption, "This is a test table.");
+        assert_eq!(tables[0].caption.as_deref(), Some("This is a test table."));
     }
 
     #[test]

--- a/pubmed-parser/tests/integration/parsing/pmc.rs
+++ b/pubmed-parser/tests/integration/parsing/pmc.rs
@@ -53,7 +53,7 @@ fn test_comprehensive_pmc_parsing(#[from(xml_test_cases)] test_cases: Vec<PmcXml
                 successful_parses += 1;
 
                 // Basic validation
-                assert!(!article.title().is_empty(), "Article should have a title");
+                assert!(article.title().is_some(), "Article should have a title");
                 assert_eq!(
                     article.pmcid().as_str(),
                     test_case.pmcid,
@@ -63,7 +63,7 @@ fn test_comprehensive_pmc_parsing(#[from(xml_test_cases)] test_cases: Vec<PmcXml
                 // Log some statistics
                 info!(
                     filename = test_case.filename(),
-                    title = article.title().chars().take(60).collect::<String>(),
+                    title = article.title().unwrap_or("").chars().take(60).collect::<String>(),
                     authors_count = article.authors().len(),
                     sections_count = article.sections().len(),
                     references_count = article.references().len(),

--- a/pubmed-parser/tests/integration/parsing/pmc.rs
+++ b/pubmed-parser/tests/integration/parsing/pmc.rs
@@ -1,6 +1,7 @@
 use rstest::*;
 use tracing::{debug, info, warn};
 
+use pubmed_parser::pmc::domain::Section;
 use pubmed_parser::pmc::parse_pmc_xml;
 
 #[path = "../common/mod.rs"]
@@ -351,4 +352,92 @@ fn test_pmc_parsing_content_structure(#[from(xml_test_cases)] test_cases: Vec<Pm
             );
         }
     }
+}
+
+const BANNED_PLACEHOLDERS: &[&str] = &[
+    "No caption available",
+    "Unknown Source",
+    "Unknown Journal",
+    "Unknown Title",
+    "Unknown Date",
+];
+
+fn assert_not_placeholder(value: &str, context: &str) {
+    for placeholder in BANNED_PLACEHOLDERS {
+        assert_ne!(
+            value, *placeholder,
+            "Found banned placeholder \"{placeholder}\" in {context}"
+        );
+    }
+}
+
+fn check_section_placeholders(section: &Section, path: &str) {
+    for (i, fig) in section.figures.iter().enumerate() {
+        if let Some(caption) = &fig.caption {
+            assert_not_placeholder(caption, &format!("{path} > figure[{i}].caption"));
+        }
+    }
+    for (i, table) in section.tables.iter().enumerate() {
+        if let Some(caption) = &table.caption {
+            assert_not_placeholder(caption, &format!("{path} > table[{i}].caption"));
+        }
+    }
+    for (i, sub) in section.subsections.iter().enumerate() {
+        check_section_placeholders(sub, &format!("{path} > subsection[{i}]"));
+    }
+}
+
+#[rstest]
+fn test_no_placeholder_strings_in_parsed_output(
+    #[from(xml_test_cases)] test_cases: Vec<PmcXmlTestCase>,
+) {
+    let mut checked = 0;
+
+    for test_case in &test_cases {
+        let xml_content = test_case.read_xml_content_or_panic();
+        let article = match parse_pmc_xml(&xml_content, &test_case.pmcid) {
+            Ok(a) => a,
+            Err(_) => continue,
+        };
+        checked += 1;
+        let pmcid = test_case.pmcid.as_str();
+
+        // Title
+        if let Some(title) = article.title() {
+            assert_not_placeholder(title, &format!("{pmcid} title"));
+        }
+
+        // Journal
+        if let Some(jt) = &article.journal().title {
+            assert_not_placeholder(jt, &format!("{pmcid} journal.title"));
+        }
+
+        // Funding
+        for (i, f) in article.funding().iter().enumerate() {
+            if let Some(src) = &f.source {
+                assert_not_placeholder(src, &format!("{pmcid} funding[{i}].source"));
+            }
+        }
+
+        // Supplementary materials
+        for (i, s) in article.supplementary_materials.iter().enumerate() {
+            if let Some(t) = &s.title {
+                assert_not_placeholder(t, &format!("{pmcid} supp[{i}].title"));
+            }
+        }
+
+        // Sections (recursive)
+        for (i, section) in article.sections().iter().enumerate() {
+            check_section_placeholders(section, &format!("{pmcid} section[{i}]"));
+        }
+
+        info!(pmcid = pmcid, "No placeholder strings found");
+    }
+
+    assert!(checked > 0, "Expected at least one article to be checked");
+    info!(
+        checked = checked,
+        total = test_cases.len(),
+        "Placeholder string check complete"
+    );
 }


### PR DESCRIPTION
## Summary

- Replace all silent placeholder strings (`"No caption available"`, `"Unknown Source"`, `"Unknown Journal"`, `"Unknown Title"`, `"Unknown Date"`) and `unwrap_or(1)` date defaults in the PMC parser with proper `Option` types
- Add `tracing::warn!` at every fallback point so parse failures are observable instead of silently swallowed
- Add integration test that parses all XML fixtures and asserts no banned placeholder strings appear in the output

## Breaking domain model changes

| Field | Before | After |
|---|---|---|
| `Figure.caption` | `String` | `Option<String>` |
| `Table.caption` | `String` | `Option<String>` |
| `FundingInfo.source` | `String` | `Option<String>` |
| `JournalMeta.title` | `String` | `Option<String>` |
| `TitleGroup.article_title` | `String` | `Option<String>` |
| `PmcArticle::title()` | `&str` | `Option<&str>` |
| `extract_pub_date()` | `String` | `Option<String>` |
| `extract_title()` | `String` | `Option<String>` |

All downstream consumers updated across 8 crates: pubmed-parser, pubmed-formatter, pubmed-client, pubmed-cli, pubmed-mcp, pubmed-client-napi, pubmed-client-wasm, pubmed-client-py (including Python type stubs).

## Test plan

- [x] All 416 workspace unit tests pass (`cargo test --workspace --lib`)
- [x] New `test_no_placeholder_strings_in_parsed_output` parses all 22 XML fixtures and recursively checks every title, caption, funding source, and supplementary material title
- [x] `cargo clippy --workspace` clean
- [x] Pre-commit hooks pass (cargo fmt, trailing whitespace, etc.)
- [ ] Verify pre-existing integration test failures (mocked_figures, parsing_pmc basic validity) are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBVbFJcgstfXQevQFTj4Xy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBVbFJcgstfXQevQFTj4Xy)_