### PR TITLE
Extract common MCP tool helpers into shared module

### DIFF
--- a/pubmed-mcp/src/tools/citmatch.rs
+++ b/pubmed-mcp/src/tools/citmatch.rs
@@ -2,9 +2,9 @@
 
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
 
+use super::common::{internal_error, text_result};
 use pubmed_client::CitationQuery;
 
 /// Single citation input for matching
@@ -46,9 +46,7 @@ pub async fn match_citations(
     Parameters(params): Parameters<CitMatchRequest>,
 ) -> Result<CallToolResult, ErrorData> {
     if params.citations.is_empty() {
-        return Ok(CallToolResult::success(vec![Content::text(
-            "No citations provided.",
-        )]));
+        return text_result("No citations provided.");
     }
 
     let citations: Vec<CitationQuery> = params
@@ -77,11 +75,7 @@ pub async fn match_citations(
         .pubmed
         .match_citations(&citations)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Citation match failed: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Citation match failed: {}", e)))?;
 
     let mut output = format!(
         "Matched {} of {} citations:\n\n",
@@ -109,5 +103,5 @@ pub async fn match_citations(
         }
     }
 
-    Ok(CallToolResult::success(vec![Content::text(output)]))
+    text_result(output)
 }

--- a/pubmed-mcp/src/tools/common.rs
+++ b/pubmed-mcp/src/tools/common.rs
@@ -1,0 +1,52 @@
+//! Shared helpers for MCP tool implementations
+
+use pubmed_client::{Figure, Section, Table};
+use rmcp::model::*;
+use std::borrow::Cow;
+use std::fmt::Display;
+
+pub fn internal_error(msg: impl Display) -> ErrorData {
+    ErrorData {
+        code: ErrorCode(-32603),
+        message: Cow::from(msg.to_string()),
+        data: None,
+    }
+}
+
+pub fn invalid_params(msg: impl Display) -> ErrorData {
+    ErrorData {
+        code: ErrorCode(-32602),
+        message: Cow::from(msg.to_string()),
+        data: None,
+    }
+}
+
+pub fn text_result(s: impl Into<String>) -> Result<CallToolResult, ErrorData> {
+    Ok(CallToolResult::success(vec![Content::text(s.into())]))
+}
+
+pub fn normalize_pmc_id(pmc_id: &str) -> String {
+    if pmc_id.starts_with("PMC") {
+        pmc_id.to_string()
+    } else {
+        format!("PMC{}", pmc_id)
+    }
+}
+
+pub fn collect_figures(sections: &[Section]) -> Vec<&Figure> {
+    let mut figures = Vec::new();
+    for section in sections {
+        figures.extend(section.figures.iter());
+        figures.extend(collect_figures(&section.subsections));
+    }
+    figures
+}
+
+pub fn collect_tables(sections: &[Section]) -> Vec<&Table> {
+    let mut tables = Vec::new();
+    for section in sections {
+        tables.extend(section.tables.iter());
+        tables.extend(collect_tables(&section.subsections));
+    }
+    tables
+}

--- a/pubmed-mcp/src/tools/convert.rs
+++ b/pubmed-mcp/src/tools/convert.rs
@@ -2,8 +2,9 @@
 
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
+
+use super::common::{internal_error, text_result};
 
 /// Request parameters for pmid_to_pmcid tool
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -24,11 +25,7 @@ pub async fn pmid_to_pmcid(
         .pmc
         .check_pmc_availability(&params.pmid)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to check PMC availability: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to check PMC availability: {}", e)))?;
 
     let result = match pmc_id {
         Some(pmcid) => format!(
@@ -41,5 +38,5 @@ pub async fn pmid_to_pmcid(
         ),
     };
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }

--- a/pubmed-mcp/src/tools/einfo.rs
+++ b/pubmed-mcp/src/tools/einfo.rs
@@ -2,8 +2,9 @@
 
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
+
+use super::common::{internal_error, text_result};
 
 /// Request parameters for list_databases tool
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -26,11 +27,7 @@ pub async fn list_databases(
         .pubmed
         .get_database_list()
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to list databases: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to list databases: {}", e)))?;
 
     let filtered: Vec<&String> = if let Some(ref filter) = params.filter {
         let filter_lower = filter.to_lowercase();
@@ -47,7 +44,7 @@ pub async fn list_databases(
         result.push_str(&format!("- {}\n", db));
     }
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }
 
 /// Request parameters for get_database_info tool
@@ -78,11 +75,7 @@ pub async fn get_database_info(
         .pubmed
         .get_database_info(&params.database)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to get database info: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to get database info: {}", e)))?;
 
     let mut result = String::new();
 
@@ -129,5 +122,5 @@ pub async fn get_database_info(
         }
     }
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }

--- a/pubmed-mcp/src/tools/elink.rs
+++ b/pubmed-mcp/src/tools/elink.rs
@@ -2,8 +2,9 @@
 
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
+
+use super::common::{internal_error, invalid_params, text_result};
 
 /// Request parameters for get_related_articles tool
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -21,11 +22,7 @@ pub async fn get_related_articles(
     Parameters(params): Parameters<RelatedArticlesRequest>,
 ) -> Result<CallToolResult, ErrorData> {
     if params.pmids.is_empty() {
-        return Err(ErrorData {
-            code: ErrorCode(-32602),
-            message: Cow::from("At least one PMID is required"),
-            data: None,
-        });
+        return Err(invalid_params("At least one PMID is required"));
     }
 
     let max = params.max_results.unwrap_or(20);
@@ -41,11 +38,7 @@ pub async fn get_related_articles(
         .pubmed
         .get_related_articles(&params.pmids)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to get related articles: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to get related articles: {}", e)))?;
 
     let displayed: Vec<_> = related.related_pmids.iter().take(max).collect();
     let total = related.related_pmids.len();
@@ -65,7 +58,7 @@ pub async fn get_related_articles(
         result.push_str(&format!("\n... and {} more", total - max));
     }
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }
 
 /// Request parameters for get_citations tool
@@ -84,11 +77,7 @@ pub async fn get_citations(
     Parameters(params): Parameters<CitationsRequest>,
 ) -> Result<CallToolResult, ErrorData> {
     if params.pmids.is_empty() {
-        return Err(ErrorData {
-            code: ErrorCode(-32602),
-            message: Cow::from("At least one PMID is required"),
-            data: None,
-        });
+        return Err(invalid_params("At least one PMID is required"));
     }
 
     let max = params.max_results.unwrap_or(50);
@@ -104,11 +93,7 @@ pub async fn get_citations(
         .pubmed
         .get_citations(&params.pmids)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to get citations: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to get citations: {}", e)))?;
 
     let displayed: Vec<_> = citations.citing_pmids.iter().take(max).collect();
     let total = citations.citing_pmids.len();
@@ -130,7 +115,7 @@ pub async fn get_citations(
 
     result.push_str("\nNote: Citation counts reflect PubMed-indexed articles only. Google Scholar and other sources may report higher counts.");
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }
 
 /// Request parameters for get_pmc_links tool
@@ -148,11 +133,7 @@ pub async fn get_pmc_links(
     Parameters(params): Parameters<PmcLinksRequest>,
 ) -> Result<CallToolResult, ErrorData> {
     if params.pmids.is_empty() {
-        return Err(ErrorData {
-            code: ErrorCode(-32602),
-            message: Cow::from("At least one PMID is required"),
-            data: None,
-        });
+        return Err(invalid_params("At least one PMID is required"));
     }
 
     info!(
@@ -165,11 +146,7 @@ pub async fn get_pmc_links(
         .pubmed
         .get_pmc_links(&params.pmids)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to get PMC links: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to get PMC links: {}", e)))?;
 
     let mut result = format!(
         "Checked {} PMIDs, found {} with PMC full text:\n\n",
@@ -185,5 +162,5 @@ pub async fn get_pmc_links(
         result.push_str("No PMC full-text articles found for the given PMIDs.\n");
     }
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }

--- a/pubmed-mcp/src/tools/espell.rs
+++ b/pubmed-mcp/src/tools/espell.rs
@@ -2,8 +2,9 @@
 
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
+
+use super::common::{internal_error, text_result};
 
 /// Spell check request parameters
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -33,11 +34,7 @@ pub async fn spell_check(
         .pubmed
         .spell_check_db(&params.term, db)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Spell check failed: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Spell check failed: {}", e)))?;
 
     let mut output = format!("Database: {}\n", result.database);
     output.push_str(&format!("Original query: \"{}\"\n", result.query));
@@ -53,5 +50,5 @@ pub async fn spell_check(
         output.push_str("\nNo spelling corrections needed.\n");
     }
 
-    Ok(CallToolResult::success(vec![Content::text(output)]))
+    text_result(output)
 }

--- a/pubmed-mcp/src/tools/export.rs
+++ b/pubmed-mcp/src/tools/export.rs
@@ -3,8 +3,9 @@
 use pubmed_client::ExportFormat as _;
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
+
+use super::common::{internal_error, invalid_params, text_result};
 
 /// Export format for citations
 #[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
@@ -36,11 +37,7 @@ pub async fn export_citations(
     Parameters(params): Parameters<ExportRequest>,
 ) -> Result<CallToolResult, ErrorData> {
     if params.pmids.is_empty() {
-        return Err(ErrorData {
-            code: ErrorCode(-32602),
-            message: Cow::from("At least one PMID is required"),
-            data: None,
-        });
+        return Err(invalid_params("At least one PMID is required"));
     }
 
     let format = params.format.unwrap_or(ExportFormat::Bibtex);
@@ -57,23 +54,16 @@ pub async fn export_citations(
         "Exporting citations"
     );
 
-    // Fetch articles
     let pmid_refs: Vec<&str> = params.pmids.iter().map(|s| s.as_str()).collect();
     let articles = server
         .client
         .pubmed
         .fetch_articles(&pmid_refs)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to fetch articles: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to fetch articles: {}", e)))?;
 
     if articles.is_empty() {
-        return Ok(CallToolResult::success(vec![Content::text(
-            "No articles found for the given PMIDs.",
-        )]));
+        return text_result("No articles found for the given PMIDs.");
     }
 
     let result = match format {
@@ -90,5 +80,5 @@ pub async fn export_citations(
             .join("\n\n"),
     };
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }

--- a/pubmed-mcp/src/tools/figures.rs
+++ b/pubmed-mcp/src/tools/figures.rs
@@ -1,10 +1,12 @@
 //! Figure extraction tool for PMC articles
 
-use pubmed_client::{Figure, Section, Table};
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
+
+use super::common::{
+    collect_figures, collect_tables, internal_error, normalize_pmc_id, text_result,
+};
 
 /// Request parameters for get_pmc_figures tool
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -13,36 +15,12 @@ pub struct FiguresRequest {
     pub pmc_id: String,
 }
 
-/// Collect all figures from sections recursively
-fn collect_figures(sections: &[Section]) -> Vec<&Figure> {
-    let mut figures = Vec::new();
-    for section in sections {
-        figures.extend(section.figures.iter());
-        figures.extend(collect_figures(&section.subsections));
-    }
-    figures
-}
-
-/// Collect all tables from sections recursively
-fn collect_tables(sections: &[Section]) -> Vec<&Table> {
-    let mut tables = Vec::new();
-    for section in sections {
-        tables.extend(section.tables.iter());
-        tables.extend(collect_tables(&section.subsections));
-    }
-    tables
-}
-
 /// Get figure and table metadata from a PMC article
 pub async fn get_pmc_figures(
     server: &super::PubMedServer,
     Parameters(params): Parameters<FiguresRequest>,
 ) -> Result<CallToolResult, ErrorData> {
-    let pmc_id = if params.pmc_id.starts_with("PMC") {
-        params.pmc_id.clone()
-    } else {
-        format!("PMC{}", params.pmc_id)
-    };
+    let pmc_id = normalize_pmc_id(&params.pmc_id);
 
     info!(pmc_id = %pmc_id, "Extracting figures from PMC article");
 
@@ -51,11 +29,7 @@ pub async fn get_pmc_figures(
         .pmc
         .fetch_full_text(&pmc_id)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to fetch PMC article: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to fetch PMC article: {}", e)))?;
 
     let mut result = format!(
         "Figures from: {} ({})\n\n",
@@ -99,5 +73,5 @@ pub async fn get_pmc_figures(
         }
     }
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }

--- a/pubmed-mcp/src/tools/fulltext.rs
+++ b/pubmed-mcp/src/tools/fulltext.rs
@@ -1,10 +1,12 @@
 //! Full-text retrieval tool for PMC articles
 
-use pubmed_client::{Figure, Section, Table};
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
+
+use super::common::{
+    collect_figures, collect_tables, internal_error, normalize_pmc_id, text_result,
+};
 
 /// Request parameters for get_pmc_fulltext tool
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -19,36 +21,12 @@ pub struct FullTextRequest {
     pub max_sections: Option<usize>,
 }
 
-/// Collect all figures from sections recursively
-fn collect_figures(sections: &[Section]) -> Vec<&Figure> {
-    let mut figures = Vec::new();
-    for section in sections {
-        figures.extend(section.figures.iter());
-        figures.extend(collect_figures(&section.subsections));
-    }
-    figures
-}
-
-/// Collect all tables from sections recursively
-fn collect_tables(sections: &[Section]) -> Vec<&Table> {
-    let mut tables = Vec::new();
-    for section in sections {
-        tables.extend(section.tables.iter());
-        tables.extend(collect_tables(&section.subsections));
-    }
-    tables
-}
-
 /// Get structured full-text content from a PMC article
 pub async fn get_pmc_fulltext(
     server: &super::PubMedServer,
     Parameters(params): Parameters<FullTextRequest>,
 ) -> Result<CallToolResult, ErrorData> {
-    let pmc_id = if params.pmc_id.starts_with("PMC") {
-        params.pmc_id.clone()
-    } else {
-        format!("PMC{}", params.pmc_id)
-    };
+    let pmc_id = normalize_pmc_id(&params.pmc_id);
 
     let include_refs = params.include_references.unwrap_or(false);
 
@@ -59,11 +37,7 @@ pub async fn get_pmc_fulltext(
         .pmc
         .fetch_full_text(&pmc_id)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to fetch PMC article: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to fetch PMC article: {}", e)))?;
 
     let mut result = String::new();
 
@@ -147,5 +121,5 @@ pub async fn get_pmc_fulltext(
         }
     }
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }

--- a/pubmed-mcp/src/tools/gquery.rs
+++ b/pubmed-mcp/src/tools/gquery.rs
@@ -2,8 +2,9 @@
 
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
+
+use super::common::{internal_error, text_result};
 
 /// Global query request parameters
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -33,11 +34,7 @@ pub async fn global_query(
         .pubmed
         .global_query(&params.term)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Global query failed: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Global query failed: {}", e)))?;
 
     let mut output = format!("Query: \"{}\"\n\n", results.term);
 
@@ -65,5 +62,5 @@ pub async fn global_query(
         output.push_str(&format!("| {} | {} |\n", db.menu_name, db.count));
     }
 
-    Ok(CallToolResult::success(vec![Content::text(output)]))
+    text_result(output)
 }

--- a/pubmed-mcp/src/tools/markdown.rs
+++ b/pubmed-mcp/src/tools/markdown.rs
@@ -2,9 +2,9 @@
 
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
 
+use super::common::{internal_error, normalize_pmc_id, text_result};
 use pubmed_client::PmcMarkdownConverter;
 
 /// Request parameters for PMC markdown conversion
@@ -25,28 +25,17 @@ pub async fn get_pmc_markdown(
     server: &super::PubMedServer,
     Parameters(params): Parameters<MarkdownRequest>,
 ) -> Result<CallToolResult, ErrorData> {
-    // Normalize PMC ID (add PMC prefix if missing)
-    let pmc_id = if params.pmc_id.starts_with("PMC") {
-        params.pmc_id.clone()
-    } else {
-        format!("PMC{}", params.pmc_id)
-    };
+    let pmc_id = normalize_pmc_id(&params.pmc_id);
 
     info!(pmc_id = %pmc_id, "Fetching PMC article for markdown conversion");
 
-    // Fetch the full-text article
     let article = server
         .client
         .pmc
         .fetch_full_text(&pmc_id)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Failed to fetch PMC article: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Failed to fetch PMC article: {}", e)))?;
 
-    // Build markdown converter with configuration
     let converter = PmcMarkdownConverter::new()
         .with_include_metadata(params.include_metadata.unwrap_or(true))
         .with_include_figure_captions(params.include_figure_captions.unwrap_or(true));
@@ -56,8 +45,7 @@ pub async fn get_pmc_markdown(
         "Converting PMC article to markdown"
     );
 
-    // Convert to markdown
     let markdown = converter.convert(&article);
 
-    Ok(CallToolResult::success(vec![Content::text(markdown)]))
+    text_result(markdown)
 }

--- a/pubmed-mcp/src/tools/mod.rs
+++ b/pubmed-mcp/src/tools/mod.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 pub mod citmatch;
+pub mod common;
 pub mod convert;
 pub mod einfo;
 pub mod elink;

--- a/pubmed-mcp/src/tools/search.rs
+++ b/pubmed-mcp/src/tools/search.rs
@@ -2,9 +2,9 @@
 
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
 
+use super::common::{internal_error, text_result};
 use pubmed_client::{ArticleType, SearchQuery, SortOrder};
 
 /// Study type filter for PubMed searches
@@ -152,13 +152,11 @@ pub async fn search_pubmed(
     // Build search query with filters
     let mut search_query = SearchQuery::new().query(&params.query);
 
-    // Apply study type filter
     if let Some(ref study_type) = params.study_type {
         let article_type = study_type.to_article_type();
         search_query = search_query.article_type(article_type);
     }
 
-    // Apply text availability filter
     if let Some(ref text_availability) = params.text_availability {
         search_query = match text_availability {
             TextAvailability::FreeFullText => search_query.free_full_text_only(),
@@ -167,12 +165,10 @@ pub async fn search_pubmed(
         };
     }
 
-    // Apply date range filter
     if let Some(start_year) = params.start_year {
         search_query = search_query.date_range(start_year, params.end_year);
     }
 
-    // Apply sort order
     if let Some(ref sort_order) = params.sort {
         search_query = search_query.sort(sort_order.to_sort_order());
     }
@@ -195,11 +191,7 @@ pub async fn search_pubmed(
         .pubmed
         .search_and_fetch(&query_string, max, search_query.get_sort())
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Search failed: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Search failed: {}", e)))?;
 
     let mut result = String::new();
 
@@ -232,7 +224,6 @@ pub async fn search_pubmed(
     result.push_str(&format!("Found {} articles:\n\n", articles.len()));
 
     for (i, article) in articles.iter().enumerate() {
-        // Format article with PMC ID if available
         if let Some(ref pmc_id) = article.pmc_id {
             result.push_str(&format!(
                 "{}. {} (PMID: {} | PMC: {})\n",
@@ -250,7 +241,6 @@ pub async fn search_pubmed(
             ));
         }
 
-        // Add abstract preview if available and requested
         if include_abstract && let Some(ref abstract_text) = article.abstract_text {
             let preview = if abstract_text.len() > 200 {
                 format!("{}...", &abstract_text[..200])
@@ -262,5 +252,5 @@ pub async fn search_pubmed(
         result.push('\n');
     }
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }

--- a/pubmed-mcp/src/tools/summary.rs
+++ b/pubmed-mcp/src/tools/summary.rs
@@ -2,8 +2,9 @@
 
 use rmcp::{handler::server::wrapper::Parameters, model::*, schemars};
 use serde::Deserialize;
-use std::borrow::Cow;
 use tracing::info;
+
+use super::common::{internal_error, invalid_params, text_result};
 
 /// Request parameters for fetch_summaries tool
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -24,11 +25,7 @@ pub async fn fetch_summaries(
     Parameters(params): Parameters<SummaryRequest>,
 ) -> Result<CallToolResult, ErrorData> {
     if params.pmids.is_empty() {
-        return Err(ErrorData {
-            code: ErrorCode(-32602),
-            message: Cow::from("At least one PMID is required"),
-            data: None,
-        });
+        return Err(invalid_params("At least one PMID is required"));
     }
 
     info!(
@@ -43,11 +40,7 @@ pub async fn fetch_summaries(
         .pubmed
         .fetch_summaries(&pmid_refs)
         .await
-        .map_err(|e| ErrorData {
-            code: ErrorCode(-32603),
-            message: Cow::from(format!("Fetch summaries failed: {}", e)),
-            data: None,
-        })?;
+        .map_err(|e| internal_error(format!("Fetch summaries failed: {}", e)))?;
 
     let mut result = String::new();
     result.push_str(&format!("Retrieved {} summaries:\n\n", summaries.len()));
@@ -114,5 +107,5 @@ pub async fn fetch_summaries(
         result.push('\n');
     }
 
-    Ok(CallToolResult::success(vec![Content::text(result)]))
+    text_result(result)
 }


### PR DESCRIPTION
## Summary

Refactor MCP tool implementations to eliminate code duplication by extracting common helper functions into a new `common` module. This improves maintainability and consistency across all tool handlers.

## Key Changes

- **New `tools/common.rs` module** with shared helpers:
  - `internal_error()` — Creates ErrorData with code -32603 (internal error)
  - `invalid_params()` — Creates ErrorData with code -32602 (invalid params)
  - `text_result()` — Wraps string results in CallToolResult::success
  - `normalize_pmc_id()` — Adds "PMC" prefix to IDs if missing
  - `collect_figures()` — Recursively collects figures from sections
  - `collect_tables()` — Recursively collects tables from sections

- **Updated all tool modules** to use common helpers:
  - `elink.rs` — Replaced 9 inline error constructions with helper calls
  - `figures.rs` — Removed duplicate `collect_figures`/`collect_tables`, use `normalize_pmc_id`
  - `fulltext.rs` — Removed duplicate collection functions, use shared helpers
  - `export.rs` — Replaced error handling with common helpers
  - `markdown.rs` — Use `normalize_pmc_id` and `text_result`
  - `einfo.rs`, `summary.rs`, `search.rs`, `citmatch.rs`, `convert.rs`, `espell.rs`, `gquery.rs` — Consistent error handling via common module

- **Removed redundant code**:
  - Eliminated duplicate `collect_figures`/`collect_tables` implementations from `figures.rs` and `fulltext.rs`
  - Consolidated PMC ID normalization logic
  - Standardized error response construction across all tools

## Implementation Details

All error handling now uses consistent error codes per JSON-RPC 2.0 spec:
- `-32603` for internal server errors (API failures, fetch errors)
- `-32602` for invalid request parameters (empty PMID lists, etc.)

The `text_result()` helper simplifies the common pattern of wrapping string output in a successful CallToolResult, reducing boilerplate across all tool handlers.

https://claude.ai/code/session_01F47SVeqZjug5cAjqysSiMw