### PR TITLE
Introduce agent-lens for code health

### DIFF
--- a/.claude/agents/code-health.md
+++ b/.claude/agents/code-health.md
@@ -1,0 +1,64 @@
+---
+name: code-health
+description: Run the agent-lens.toml profiles, filter out this repo's by-design boilerplate, and return a synthesized, prioritized code-health report. Use when the user wants refactor targets, duplication/complexity/cohesion findings, hotspots, or an architecture/coupling audit of the Rust workspace — the raw analyzer reports are large, so this agent absorbs them and returns only the conclusions.
+tools: Bash, Read, Grep, Glob
+model: sonnet
+---
+
+You are a code-health investigator for the `pubmed-client-rs` Cargo workspace. You run
+the `agent-lens` analyzers via the tuned profiles in the root `agent-lens.toml`, read
+the (large) raw reports yourself, and return a compact, prioritized findings list — the
+caller should never need to see the raw output.
+
+## How to run
+
+Prefer `agent-lens run <profile>` over ad-hoc `agent-lens analyze`. Profiles:
+
+- `agent-lens run hotspot` — `commits × cognitive_max` ranking; **start here**.
+- `agent-lens run quality` — similarity + wrapper + cohesion + complexity, whole workspace.
+- `agent-lens run review` — same four, but `--diff-only` (pre-commit gate; empty == good).
+- `agent-lens run coupling` — module coupling + context-span for the `pubmed-client` crate.
+
+Scope to what's asked: a "where should I refactor?" question only needs `hotspot` +
+`quality`; a "did my diff regress anything?" question only needs `review`; an
+"audit the architecture" question only needs `coupling` (and you may also run
+`agent-lens analyze coupling pubmed-parser/src/lib.rs --format md` for other crates).
+Override per-invocation with `agent-lens analyze <tool> <path> --format md` and flags
+(`--threshold`, `--min-lines`, `--top`, `--since`, `--exclude`) when you need to narrow.
+
+## Filter out by-design boilerplate (do NOT report these as defects)
+
+This is a layered workspace (`pubmed-parser` → `pubmed-formatter` → `pubmed-client` →
+bindings/cli/mcp). The following dominate the raw reports but are intentional:
+
+- **Binding glue** in `pubmed-client-py/`, `pubmed-client-napi/src/lib.rs`,
+  `pubmed-client-wasm/src/lib.rs` — `*::from` DTO mappers and `fetch_*`/`get_*` methods
+  forwarding to the core crate. Per-language macros (PyO3/napi/wasm); cannot share impl.
+- **`Client::*` facade** in `pubmed-client/src/lib.rs` forwarding to `self.pubmed.*` —
+  the documented unified-client convenience API.
+- **`PmcArticle::doi`/`title`/… accessors** in `pmc/domain.rs` forwarding to nested
+  `front.article_meta.*` — the documented flat accessor layer.
+- **Builder setters** (`ClientConfig`, `WasmClientConfig`, `RetryConfig`, `SearchQuery`
+  date/boolean variants) — high LCOM4 / similarity is the natural shape of a builder.
+- **`examples/**` and `benches/**`** duplication — standalone demo/bench code.
+
+When binding-crate noise drowns the core, re-run scoped to the Rust core:
+`agent-lens analyze similarity pubmed-parser pubmed-formatter pubmed-client --format md`.
+
+## What IS worth reporting
+
+Genuine logic complexity (epicentre: `pubmed-parser/src/pmc/parser/` — `author.rs`,
+`section.rs`, `metadata.rs`, plus `pubmed-client/src/pmc/tar.rs`), accidental duplicates
+_within a single core crate_ (e.g. `format_first_pub_date` across the two markdown
+modules, `format_author_name` across parser modules), thin wrappers that should collapse
+onto a canonical shared helper, and — for coupling — any **cycle (count > 0)** or new
+dependency that inverts the `parser → formatter → client` layering.
+
+## Output
+
+Return a prioritized list, not raw dumps. For each finding:
+`file:line` · one-line description · why it's actionable (or why a flagged item is
+benign, if the user asked about it) · suggested action. Order by impact (hotspot rank ×
+severity). End with a one-line summary (e.g. "0 cycles; layering intact; 2 real
+duplicates; top refactor target = author.rs:extract_reference_authors cog=50"). Do not
+edit code — you investigate and report; the caller decides what to change.

--- a/.claude/skills/code-health/SKILL.md
+++ b/.claude/skills/code-health/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: code-health
+description: Investigate this workspace's code health with the agent-lens.toml profiles — find refactor targets, duplication, forwarding wrappers, complexity creep, or audit module structure. Use when the user asks "where should I refactor", "what are the hotspots/landmines", "find duplicates", "is anything too complex", "audit the architecture/coupling", or wants a code-quality sweep of the Rust crates.
+---
+
+This workspace ships an [`agent-lens.toml`](../../../agent-lens.toml) at the root with
+tuned profiles. Always prefer `agent-lens run <profile>` over ad-hoc
+`agent-lens analyze` calls — the profiles already set the right paths, exclude
+fixtures/tmp/examples, and bundle the analyzers in a useful order. The binary is
+provided by mise.
+
+> The full quality sweep is large (similarity + wrapper + cohesion + complexity over
+> the whole workspace is hundreds of lines). For anything beyond a single targeted
+> profile, **delegate to the `code-health` subagent** (`Agent` tool, `subagent_type:
+> "code-health"`) so the raw reports stay out of the main context and you get back a
+> synthesized findings list.
+
+## Profiles
+
+| Profile    | Scope                                 | Analyzers                                 | Use for                                |
+| ---------- | ------------------------------------- | ----------------------------------------- | -------------------------------------- |
+| `hotspot`  | workspace (tests/fixtures excluded)   | hotspot                                   | Where churn × complexity meet          |
+| `quality`  | workspace (tests/fixtures excluded)   | similarity, wrapper, cohesion, complexity | Full static-quality sweep              |
+| `review`   | workspace, all `--diff-only`          | similarity, wrapper, cohesion, complexity | Pre-commit gate on unstaged changes    |
+| `coupling` | `pubmed-client/src/lib.rs` crate root | coupling, context-span                    | Module layering / cycles / instability |
+
+```bash
+agent-lens run hotspot      # ranked refactor targets (start here)
+agent-lens run quality      # full workspace report (markdown)
+agent-lens run review       # only what the current diff touches
+agent-lens run coupling     # one crate's module graph
+```
+
+`coupling` needs a single crate root, so it points at `pubmed-client/src/lib.rs`
+(the crate that ties the workspace together). Swap `path` in `agent-lens.toml`, or run
+`agent-lens analyze coupling pubmed-parser/src/lib.rs --format md` to inspect another
+crate.
+
+## Investigation workflow
+
+1. **Start with `hotspot`.** It ranks `commits × cognitive_max` — "frequently changed
+   _and_ complex". The top ~5 files are where bugs concentrate and refactors pay off.
+2. **Drill into `complexity`** for those files. The per-function list gives exact line
+   ranges (`file:Func (L238-317): cog=50`). Sort by **cognitive**, not cyclomatic.
+3. **Cross-check `similarity` + `wrapper`** to see whether the complexity is genuine
+   logic or copy-paste / thin forwarding that should be unified.
+4. **For structure questions, run `coupling`.** Read `instability` (`Ce/(Ca+Ce)`),
+   Fan-In/Fan-Out, IFC, and cycle count. `context-span` estimates onboarding cost (how
+   many files you must open to reason about a module).
+5. **Before committing, run `review`** to catch complexity/cohesion/duplication
+   regressions the current diff introduces. An empty report is the success case.
+6. **Report findings, then confirm before editing.** These analyzers measure
+   _shape, not semantics_ — every flagged item needs a human judgment call (see below).
+   Cite `file:line` from the report so the user can jump straight there.
+
+## Reading the output — repo-specific signal vs. noise
+
+This is a layered Rust workspace (`pubmed-parser` → `pubmed-formatter` →
+`pubmed-client` → bindings/cli/mcp). Several large clusters are **by-design
+boilerplate** — learn to skip them so the real findings stand out.
+
+### Mostly noise (intentional by design)
+
+- **Language-binding glue dominates `similarity`.** The biggest clusters live in
+  `pubmed-client-py/`, `pubmed-client-napi/src/lib.rs`, and
+  `pubmed-client-wasm/src/lib.rs` — the `*::from` DTO mappers (`Summary`/`JsSummary`/
+  `PyArticleSummary`) and the `fetch_articles` / `fetch_summaries` / `get_*` methods
+  that each forward to the same core-crate call. These are **intentional per-language
+  surfaces** built with different macros (PyO3 / napi / wasm-bindgen); they can't share
+  an implementation. Don't churn them. To focus a sweep on the Rust core, run
+  `agent-lens analyze similarity pubmed-parser pubmed-formatter pubmed-client --format md`
+  (or `--exclude 'pubmed-client-py/**' --exclude 'pubmed-client-napi/**' --exclude 'pubmed-client-wasm/**'`).
+- **`Client::*` wrappers in `pubmed-client/src/lib.rs`** (12 methods forwarding to
+  `self.pubmed.*`) are the **unified-client facade** documented in CLAUDE.md ("Unified
+  client with `pubmed` and `pmc` fields; convenience methods"). Public API, not a smell.
+- **`PmcArticle::doi`/`title`/`volume`/… in `pmc/domain.rs`** forwarding to nested
+  `front.article_meta.*` are the **flat accessor layer** CLAUDE.md describes ("Single
+  PMC model layer; flat read access via accessor methods"). Intentional.
+- **Builder-setter cohesion** — `WasmClientConfig` (LCOM4=5), `ClientConfig` (LCOM4=6),
+  `RetryConfig` — each `with_*` setter touches a different field, so a high LCOM4 is the
+  expected shape of a builder, not a defect.
+- **`SearchQuery::published_between` / `entry_date_between` / `modification_date_between`**
+  (≈98% similar) and `and`/`or`, `negate`/`group` in `query/boolean.rs` are
+  builder-pattern variants. A shared private helper is _possible_ but low-value/low-risk.
+- **`examples/**` and `benches/**` duplication** (`build_batch_xml`, `display_article`,
+  `load_all_*_xmls`) is demo/bench code kept standalone for readability.
+
+### Real, actionable signal
+
+- **`pubmed-parser/src/pmc/parser/` is the complexity epicentre.**
+  `author.rs:extract_reference_authors` (cog=50, the workspace max),
+  `section.rs:parse_section_from_body` (cog=39) and `extract_body_sections` (cog=29),
+  `xml_utils.rs:decode_xml_entities` (cog=37). `section.rs`, `metadata.rs`, `author.rs`
+  are also top hotspots. These are genuine parsing logic — split/simplify candidates.
+- **`pubmed-client/src/pmc/tar.rs` is the #1 hotspot** (score 340, heavy churn +
+  `find_matching_file` cog=34). Watch this file on every change.
+- **Genuine accidental duplicates** worth unifying (same logic, _within the Rust core_):
+  - `format_first_pub_date` is **100% duplicated** across
+    `pubmed-formatter/src/pmc/markdown/frontmatter.rs` and `.../markdown/metadata.rs`.
+  - `format_author_name` is ~94% duplicated across `pubmed-parser/src/common/models.rs`
+    and `pubmed-parser/src/pubmed/parser/extractors.rs`.
+  - `PubMedId::try_from_u32` / `PmcId::try_from_u32` in `common/ids.rs` and
+    `PmcXmlTestCase::new` / `PubMedXmlTestCase::new` in `pubmed-test-utils` are
+    type-paired — macro candidates if the pattern grows.
+- **`wrapper` to shared helpers** is actionable when a thin per-module wrapper exists
+  only to forward to a canonical helper (e.g. `PmcClient::normalize_pmcid` →
+  `common::normalize_pmcid`). The repo prefers one unified helper over parallel variants.
+- **`coupling` on `pubmed-client`**: `crate::error` is a high-Fan-In/low-Fan-Out stable
+  hub (healthy); `pmc::client` / `pmc::tar` are intentionally high-instability leaves.
+  The signal to watch is **cycle count > 0** (currently 0) — flag any new cross-crate
+  cycle or new dependency that inverts the `parser → formatter → client` layering.
+
+## Tuning
+
+Adjust thresholds in [`agent-lens.toml`](../../../agent-lens.toml), or override
+per-invocation with `agent-lens analyze <tool> <path> --format md` flags
+(`--threshold`, `--min-lines`, `--top`, `--diff-only`, `--since`, `--exclude`). Full
+reference: `agent-lens help --md`.

--- a/agent-lens.toml
+++ b/agent-lens.toml
@@ -1,0 +1,84 @@
+# agent-lens.toml — multi-analyzer profiles for the pubmed-client-rs workspace.
+# Discovered by walking up from the cwd; run with `agent-lens run <profile>`.
+# Keys are kebab-case and mirror the CLI flags. Relative paths resolve against
+# this file's directory. Unknown keys are rejected at parse time.
+
+# ---------------------------------------------------------------------------
+# quality — full static-quality sweep over the whole workspace.
+# Surfaces near-duplicate functions, thin wrappers, complexity creep, and
+# weak cohesion across every crate. Tests are excluded so the report stays
+# focused on production code.
+# ---------------------------------------------------------------------------
+[profile.quality]
+path = "."
+format = "md"
+exclude-tests = true
+exclude = ["test_data/**", "tmp_*/**", "examples/**"]
+tools = ["similarity", "wrapper", "cohesion", "complexity"]
+
+[profile.quality.similarity]
+threshold = 0.85
+min-lines = 8 # ignore trivial getters / one-liners
+top = 25
+
+[profile.quality.cohesion]
+min-score = 2 # LCOM4 >= 2 (units that split into multiple components)
+top = 25
+
+[profile.quality.complexity]
+min-score = 12 # cognitive complexity floor
+top = 25
+
+# ---------------------------------------------------------------------------
+# review — pre-commit lens. Reports only the units touching unstaged changes
+# (`git diff -U0`); an empty report is the success case. Run before committing
+# to catch duplication / wrappers / complexity introduced by the current diff.
+# ---------------------------------------------------------------------------
+[profile.review]
+path = "."
+format = "md"
+exclude-tests = true
+exclude = ["test_data/**", "tmp_*/**"]
+tools = ["similarity", "wrapper", "cohesion", "complexity"]
+
+[profile.review.similarity]
+diff-only = true
+threshold = 0.85
+min-lines = 5
+
+[profile.review.cohesion]
+diff-only = true
+min-score = 2
+
+[profile.review.complexity]
+diff-only = true
+min-score = 10
+
+[profile.review.wrapper]
+diff-only = true
+
+# ---------------------------------------------------------------------------
+# hotspot — rank files by `commits × cognitive_max` to find where churn and
+# complexity meet (best refactor ROI). Must run inside a git working tree.
+# ---------------------------------------------------------------------------
+[profile.hotspot]
+path = "."
+format = "md"
+exclude-tests = true
+exclude = ["test_data/**", "tmp_*/**", "examples/**"]
+tools = ["hotspot"]
+
+[profile.hotspot.hotspot]
+since = "6.months.ago"
+top = 30
+
+# ---------------------------------------------------------------------------
+# coupling — module-level coupling for a single crate root (coupling needs one
+# entry, so point it at the crate that ties the workspace together). Swap the
+# path to inspect another crate, e.g. "pubmed-parser/src/lib.rs".
+# ---------------------------------------------------------------------------
+[profile.coupling]
+path = "pubmed-client/src/lib.rs"
+format = "md"
+exclude-tests = true
+tools = ["coupling", "context-span"]

--- a/mise.root.toml
+++ b/mise.root.toml
@@ -11,7 +11,7 @@ actionlint = "1.7.7"
 shellcheck = "0.10.0"
 "aqua:suzuki-shunsuke/ghalint" = "1.4.1"
 "aqua:suzuki-shunsuke/pinact" = "3.3.0"
-
+"github:illumination-k/agent-lens" = { version = "rolling", prerelease = true }
 # ── Format tasks ──────────────────────────────────────────────────────────────
 
 [tasks."fmt:root"]

--- a/pubmed-formatter/src/pmc/markdown/frontmatter.rs
+++ b/pubmed-formatter/src/pmc/markdown/frontmatter.rs
@@ -31,7 +31,7 @@ pub(super) struct ArticleMetadata {
     publisher: Option<String>,
 }
 
-fn format_first_pub_date(dates: &[PublicationDate]) -> Option<String> {
+pub(super) fn format_first_pub_date(dates: &[PublicationDate]) -> Option<String> {
     let d = dates.first()?;
     let year = d.year?;
     match (d.month, d.day) {

--- a/pubmed-formatter/src/pmc/markdown/metadata.rs
+++ b/pubmed-formatter/src/pmc/markdown/metadata.rs
@@ -1,20 +1,10 @@
-use pubmed_parser::common::{Author, PublicationDate};
+use pubmed_parser::common::Author;
 use pubmed_parser::pmc::PmcArticle;
 
 use super::config::MarkdownConfig;
 use super::entities::clean_content;
-use super::frontmatter::generate_yaml_frontmatter;
+use super::frontmatter::{format_first_pub_date, generate_yaml_frontmatter};
 use super::heading::format_heading;
-
-fn format_first_pub_date(dates: &[PublicationDate]) -> Option<String> {
-    let d = dates.first()?;
-    let year = d.year?;
-    match (d.month, d.day) {
-        (Some(m), Some(day)) => Some(format!("{year}-{m:02}-{day:02}")),
-        (Some(m), None) => Some(format!("{year}-{m:02}")),
-        _ => Some(year.to_string()),
-    }
-}
 
 pub(super) fn convert_metadata(config: &MarkdownConfig, article: &PmcArticle) -> String {
     if config.metadata.use_yaml_frontmatter {

--- a/pubmed-parser/src/pubmed/parser/converters.rs
+++ b/pubmed-parser/src/pubmed/parser/converters.rs
@@ -3,8 +3,9 @@
 //! This module handles the transformation of internal XML deserialization types
 //! into the clean public API models exposed by the library.
 
-use super::extractors::{extract_country_from_text, extract_email_from_text, format_author_name};
+use super::extractors::{extract_country_from_text, extract_email_from_text};
 use super::xml_types::*;
+use crate::common::format_author_name;
 use crate::error::{ParseError, Result};
 use crate::pubmed::models::{
     Affiliation, Author, ChemicalConcept, MeshHeading, MeshQualifier, MeshTerm, PubMedArticle,

--- a/pubmed-parser/src/pubmed/parser/extractors.rs
+++ b/pubmed-parser/src/pubmed/parser/extractors.rs
@@ -119,56 +119,6 @@ pub(super) fn extract_country_from_text(text: &str) -> Option<String> {
     })
 }
 
-/// Format an author name from components
-///
-/// Constructs a full author name from available components, handling missing fields gracefully.
-///
-/// # Arguments
-///
-/// * `last_name` - Author's last name/surname
-/// * `fore_name` - Author's fore name (given name)
-/// * `initials` - Author's initials (used if fore_name is missing)
-///
-/// # Returns
-///
-/// A formatted full name string
-///
-/// # Formatting Rules
-///
-/// 1. If both fore_name and last_name exist: "ForeNamLast
-/// 2. If only last_name exists: "Initials LastName" (if initials available) or "LastName"
-/// 3. If only fore_name exists: "ForeName"
-/// 4. If neither exists: "Unknown Author"
-///
-/// # Example
-///
-/// ```ignore
-/// let name = format_author_name(
-///     &Some("Smith".to_string()),
-///     &Some("John".to_string()),
-///     &None
-/// );
-/// assert_eq!(name, "John Smith");
-/// ```
-pub(super) fn format_author_name(
-    last_name: &Option<String>,
-    fore_name: &Option<String>,
-    initials: &Option<String>,
-) -> String {
-    match (fore_name, last_name) {
-        (Some(fore), Some(last)) => format!("{fore} {last}"),
-        (None, Some(last)) => {
-            if let Some(init) = initials {
-                format!("{init} {last}")
-            } else {
-                last.clone()
-            }
-        }
-        (Some(fore), None) => fore.clone(),
-        (None, None) => "Unknown Author".to_string(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,23 +151,5 @@ mod tests {
         );
 
         assert_eq!(extract_country_from_text("Local Institution"), None);
-    }
-
-    #[test]
-    fn test_format_author_name() {
-        assert_eq!(
-            format_author_name(&Some("Smith".to_string()), &Some("John".to_string()), &None),
-            "John Smith"
-        );
-
-        assert_eq!(
-            format_author_name(&Some("Doe".to_string()), &None, &Some("J".to_string())),
-            "J Doe"
-        );
-
-        assert_eq!(
-            format_author_name(&Some("Johnson".to_string()), &None, &None),
-            "Johnson"
-        );
     }
 }


### PR DESCRIPTION
## Summary

Introduces [agent-lens](https://github.com/illumination-k/agent-lens) as the workspace's code-health tooling, and applies the first cleanup it surfaced.

- **Tooling** — adds `agent-lens.toml` with four tuned profiles (`hotspot`, `quality`, `review`, `coupling`), plus a `code-health` skill and subagent. The skill/subagent route an agent to the right profile and document this repo's *by-design* boilerplate (per-language binding glue, the unified-client facade, PMC flat accessors, builder setters) so genuine findings stand out from the noise. (The mise install of the binary already landed in `agent-lens`.)
- **Dedup** — removes two accidental duplicate functions flagged by `agent-lens run quality`:
  - `format_first_pub_date` (100% duplicated across the markdown `frontmatter` / `metadata` modules) → one canonical copy, imported.
  - `format_author_name` (duplicated in `pubmed/parser/extractors`) → drop the local copy + redundant test, reuse the already-`pub` `common::format_author_name`.

## Test plan

- `cargo build -p pubmed-parser -p pubmed-formatter` — clean
- `cargo test -p pubmed-parser -p pubmed-formatter` — all pass
- `agent-lens analyze similarity pubmed-parser pubmed-formatter` — both duplicate clusters gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)