### PR TITLE
Refactor batch processing into shared module for CLI commands

### DIFF
--- a/pubmed-cli/src/commands/batch.rs
+++ b/pubmed-cli/src/commands/batch.rs
@@ -1,0 +1,314 @@
+//! Shared building blocks for batch CLI commands (figures, metadata, ...).
+//!
+//! Batch commands all follow the same shape: take a list of IDs, process each
+//! one independently, show a progress bar, collect per-item failures, and
+//! optionally dump those failures as JSON. This module factors out that
+//! framework so individual commands only need to describe how to process a
+//! single item.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info};
+
+use crate::commands::storage::StorageBackend;
+
+/// Categorized reason a single batch item failed.
+///
+/// Shared across batch commands so error handling improvements apply uniformly.
+/// `message` on [`BatchItemError`] carries the human-readable detail; this enum
+/// captures the machine-readable category.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureKind {
+    /// A network request timed out.
+    NetworkTimeout {
+        /// The configured timeout, in seconds.
+        timeout_seconds: u64,
+    },
+    /// A network or connection error that was not a timeout.
+    NetworkError,
+    /// The requested article/resource was not found.
+    NotFound,
+    /// The article was retrieved but contained no usable content
+    /// (e.g. no figures to extract).
+    Empty,
+    /// Fetching or downloading the source data failed.
+    FetchFailed,
+    /// Writing the output to storage failed.
+    StorageError {
+        /// The storage operation that failed (e.g. `write_metadata`).
+        operation: String,
+    },
+    /// Any other, uncategorized error.
+    Other,
+}
+
+impl fmt::Display for FailureKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NetworkTimeout { timeout_seconds } => {
+                write!(f, "network timeout after {} seconds", timeout_seconds)
+            }
+            Self::NetworkError => write!(f, "network error"),
+            Self::NotFound => write!(f, "not found"),
+            Self::Empty => write!(f, "no content"),
+            Self::FetchFailed => write!(f, "fetch failed"),
+            Self::StorageError { operation } => write!(f, "storage error during {}", operation),
+            Self::Other => write!(f, "unexpected error"),
+        }
+    }
+}
+
+/// A single failed batch item, serialized into the `--failed-output` JSON file.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchItemError {
+    /// The ID (e.g. PMC ID) of the item that failed.
+    pub id: String,
+    /// The categorized failure reason.
+    pub kind: FailureKind,
+    /// Human-readable detail (typically the full error chain).
+    pub message: String,
+}
+
+impl BatchItemError {
+    /// Create a new batch item error.
+    pub fn new(id: impl Into<String>, kind: FailureKind, message: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for BatchItemError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({}): {}", self.id, self.kind, self.message)
+    }
+}
+
+/// Inspect an error string and classify it as a timeout, not-found, or generic
+/// network failure. Helper for the common case of mapping an opaque client
+/// error into a [`FailureKind`].
+pub fn classify_fetch_error(error_str: &str, timeout_seconds: u64) -> FailureKind {
+    let lower = error_str.to_lowercase();
+    if lower.contains("timeout") || lower.contains("timed out") {
+        FailureKind::NetworkTimeout { timeout_seconds }
+    } else if lower.contains("not found") || lower.contains("404") {
+        FailureKind::NotFound
+    } else if lower.contains("network") || lower.contains("connection") {
+        FailureKind::NetworkError
+    } else {
+        FailureKind::FetchFailed
+    }
+}
+
+/// Drives a batch command: owns the progress bars and accumulates failures.
+///
+/// Construct with [`BatchProcessor::new`], run items via [`BatchProcessor::run`]
+/// (or manually with [`BatchProcessor::record`]), then [`BatchProcessor::finish`]
+/// and inspect [`BatchProcessor::failures`].
+pub struct BatchProcessor {
+    multi_progress: MultiProgress,
+    main_pb: ProgressBar,
+    total: usize,
+    failures: Vec<BatchItemError>,
+}
+
+impl BatchProcessor {
+    /// Create a processor for `total` items, setting up the main progress bar.
+    pub fn new(total: usize) -> Result<Self> {
+        let multi_progress = MultiProgress::new();
+        let main_pb = multi_progress.add(ProgressBar::new(total as u64));
+        main_pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} articles ({msg})")
+                .context("Failed to set progress bar style")?
+                .progress_chars("#>-"),
+        );
+        main_pb.set_message("Processing PMC articles");
+        Ok(Self {
+            multi_progress,
+            main_pb,
+            total,
+            failures: Vec::new(),
+        })
+    }
+
+    /// Process every ID in `ids` sequentially.
+    ///
+    /// `process` receives the shared [`MultiProgress`] and an item ID, performs
+    /// all work for that item (including writing its output), and returns
+    /// `Ok(())` on success or a [`BatchItemError`] on failure. Failures are
+    /// collected and processing continues with the next item.
+    pub async fn run<F>(&mut self, ids: &[String], process: F)
+    where
+        F: AsyncFn(&MultiProgress, &str) -> Result<(), BatchItemError>,
+    {
+        for id in ids {
+            self.main_pb.set_message(format!("Processing {}", id));
+            debug!(id = %id, "Processing batch item");
+            let result = process(&self.multi_progress, id).await;
+            self.record(id, result);
+        }
+    }
+
+    /// Record the outcome of processing a single item, updating the progress
+    /// bar and the failure list. Useful when a command needs a custom loop
+    /// instead of [`BatchProcessor::run`].
+    pub fn record(&mut self, id: &str, result: Result<(), BatchItemError>) {
+        match result {
+            Ok(()) => {
+                debug!(id = %id, "Successfully processed batch item");
+                self.main_pb.set_message(format!("Completed {}", id));
+            }
+            Err(e) => {
+                error!(id = %id, kind = %e.kind, message = %e.message, "Failed to process batch item");
+                self.main_pb.set_message(format!("Failed {}", id));
+                self.failures.push(e);
+            }
+        }
+        self.main_pb.inc(1);
+    }
+
+    /// Finish the main progress bar with a summary message.
+    pub fn finish(&self) {
+        self.main_pb.finish_with_message(format!(
+            "Processed {} articles ({} failed)",
+            self.total,
+            self.failures.len()
+        ));
+    }
+
+    /// The collected failures.
+    pub fn failures(&self) -> &[BatchItemError] {
+        &self.failures
+    }
+}
+
+/// Handle the failures collected by a [`BatchProcessor`].
+///
+/// If `failed_output` is set, the failures are serialized to JSON and written
+/// to that path (filename only, normalized to a `.json` extension) inside the
+/// given `storage` backend. Otherwise they are logged. Storage write errors are
+/// logged but not propagated, so a failure to record failures never masks the
+/// primary command result.
+pub async fn report_failures(
+    failures: &[BatchItemError],
+    failed_output: Option<PathBuf>,
+    storage: &dyn StorageBackend,
+) -> Result<()> {
+    if failures.is_empty() {
+        return Ok(());
+    }
+
+    let Some(failed_path) = failed_output else {
+        error!(
+            failed_count = failures.len(),
+            failures = ?failures,
+            "Failed to process some IDs"
+        );
+        return Ok(());
+    };
+
+    let json_content = serde_json::to_string_pretty(failures)?;
+    let json_filename = failed_output_filename(&failed_path)?;
+
+    match storage
+        .write_file(&json_filename, json_content.as_bytes())
+        .await
+    {
+        Ok(()) => info!(
+            path = %storage.get_full_path(&json_filename),
+            count = failures.len(),
+            "Saved failed IDs to JSON file"
+        ),
+        Err(e) => error!(
+            path = %failed_path.display(),
+            error = %e,
+            "Failed to save failed IDs to JSON file"
+        ),
+    }
+
+    Ok(())
+}
+
+/// Extract the filename from `path` and ensure it ends with `.json`.
+fn failed_output_filename(path: &Path) -> Result<String> {
+    let filename = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow::anyhow!("Invalid failed output path: {}", path.display()))?;
+
+    Ok(if filename.ends_with(".json") {
+        filename.to_string()
+    } else {
+        format!("{}.json", filename.trim_end_matches('.'))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_fetch_error() {
+        assert!(matches!(
+            classify_fetch_error("request timed out", 30),
+            FailureKind::NetworkTimeout {
+                timeout_seconds: 30
+            }
+        ));
+        assert!(matches!(
+            classify_fetch_error("HTTP 404 returned", 30),
+            FailureKind::NotFound
+        ));
+        assert!(matches!(
+            classify_fetch_error("Article not found", 30),
+            FailureKind::NotFound
+        ));
+        assert!(matches!(
+            classify_fetch_error("connection reset", 30),
+            FailureKind::NetworkError
+        ));
+        assert!(matches!(
+            classify_fetch_error("something odd", 30),
+            FailureKind::FetchFailed
+        ));
+    }
+
+    #[test]
+    fn test_failed_output_filename() {
+        assert_eq!(
+            failed_output_filename(Path::new("/tmp/failed.json")).unwrap(),
+            "failed.json"
+        );
+        assert_eq!(
+            failed_output_filename(Path::new("failed")).unwrap(),
+            "failed.json"
+        );
+        assert_eq!(
+            failed_output_filename(Path::new("dir/failed.")).unwrap(),
+            "failed.json"
+        );
+    }
+
+    #[test]
+    fn test_failure_kind_serialization() {
+        let err = BatchItemError::new(
+            "PMC123",
+            FailureKind::NetworkTimeout {
+                timeout_seconds: 60,
+            },
+            "boom",
+        );
+        let json = serde_json::to_string(&err).unwrap();
+        assert!(json.contains("\"id\":\"PMC123\""));
+        assert!(json.contains("network_timeout"));
+        assert!(json.contains("\"timeout_seconds\":60"));
+    }
+}

--- a/pubmed-cli/src/commands/export.rs
+++ b/pubmed-cli/src/commands/export.rs
@@ -1,10 +1,12 @@
 use std::io::Write;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Args;
 use pubmed_client::ExportFormat;
 
 use super::{CitationFormat, ClientContext};
+use crate::commands::storage::create_file_storage;
 
 #[derive(Args, Debug)]
 pub struct Export {
@@ -17,8 +19,16 @@ pub struct Export {
     pub format: CitationFormat,
 
     /// Output file (default: stdout)
-    #[arg(short, long)]
-    pub output: Option<std::path::PathBuf>,
+    #[arg(short, long, conflicts_with = "s3_path")]
+    pub output: Option<PathBuf>,
+
+    /// S3 path for the exported file (e.g., s3://bucket/prefix/citations.bib)
+    #[arg(long, conflicts_with = "output")]
+    pub s3_path: Option<String>,
+
+    /// AWS region for S3 (optional, uses default AWS config if not specified)
+    #[arg(long, requires = "s3_path")]
+    pub s3_region: Option<String>,
 }
 
 impl Export {
@@ -53,19 +63,38 @@ impl Export {
                 .join("\n\n"),
         };
 
-        if let Some(ref output_path) = self.output {
-            std::fs::write(output_path, &result)?;
-            tracing::info!(
-                path = %output_path.display(),
-                articles = articles.len(),
-                "Exported {} articles to {}",
-                articles.len(),
-                output_path.display()
-            );
-        } else {
+        // No destination given: write to stdout (default behavior).
+        if self.output.is_none() && self.s3_path.is_none() {
             write!(std::io::stdout(), "{}", result)?;
+            return Ok(());
         }
 
+        let (storage, key) = create_file_storage(
+            self.output.clone(),
+            self.s3_path.clone(),
+            self.s3_region.clone(),
+            &self.default_filename(),
+        )
+        .await?;
+
+        storage.write_file(&key, result.as_bytes()).await?;
+        tracing::info!(
+            path = %storage.get_full_path(&key),
+            articles = articles.len(),
+            "Exported {} articles",
+            articles.len(),
+        );
+
         Ok(())
+    }
+
+    fn default_filename(&self) -> String {
+        let ext = match self.format {
+            CitationFormat::Bibtex => "bib",
+            CitationFormat::Ris => "ris",
+            CitationFormat::CslJson => "json",
+            CitationFormat::Nbib => "nbib",
+        };
+        format!("citations.{}", ext)
     }
 }

--- a/pubmed-cli/src/commands/figures.rs
+++ b/pubmed-cli/src/commands/figures.rs
@@ -1,115 +1,16 @@
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tempfile::TempDir;
-use thiserror::Error;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::commands::ClientContext;
+use crate::commands::batch::{
+    BatchItemError, BatchProcessor, FailureKind, classify_fetch_error, report_failures,
+};
 use crate::commands::storage::{StorageBackend, create_storage_backend};
-
-#[derive(Error, Debug)]
-pub enum FiguresError {
-    #[error("Failed to download TAR archive for PMC ID {pmcid}: {source}")]
-    TarDownloadFailed {
-        pmcid: String,
-        #[source]
-        source: anyhow::Error,
-    },
-
-    #[error("No figures found in article {pmcid}")]
-    NoFiguresFound { pmcid: String },
-
-    #[error("Failed to save metadata for {pmcid}: {source}")]
-    MetadataSaveFailed {
-        pmcid: String,
-        path: String,
-        #[source]
-        source: anyhow::Error,
-    },
-
-    #[error("Network timeout while processing {pmcid} (timeout: {timeout_seconds}s)")]
-    NetworkTimeout { pmcid: String, timeout_seconds: u64 },
-
-    #[error("Storage backend error for {pmcid}: {source}")]
-    StorageError {
-        pmcid: String,
-        operation: String,
-        #[source]
-        source: anyhow::Error,
-    },
-
-    #[error("Unexpected error processing {pmcid}: {source}")]
-    Other {
-        pmcid: String,
-        #[source]
-        source: anyhow::Error,
-    },
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum FailureReason {
-    TarDownloadFailed {
-        message: String,
-        is_timeout: bool,
-        is_network_error: bool,
-    },
-    NoFiguresFound,
-    MetadataSaveFailed(String),
-    NetworkTimeout {
-        timeout_seconds: u64,
-    },
-    StorageError {
-        operation: String,
-        message: String,
-    },
-    Other(String),
-}
-
-impl fmt::Display for FailureReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::TarDownloadFailed {
-                message,
-                is_timeout,
-                is_network_error,
-            } => {
-                write!(
-                    f,
-                    "TAR download failed: {}{}{}]",
-                    message,
-                    if *is_timeout { " (timeout)" } else { "" },
-                    if *is_network_error {
-                        " (network error)"
-                    } else {
-                        ""
-                    }
-                )
-            }
-            Self::NoFiguresFound => write!(f, "No figures found in article"),
-            Self::MetadataSaveFailed(msg) => write!(f, "Metadata save failed: {}", msg),
-            Self::NetworkTimeout { timeout_seconds } => {
-                write!(f, "Network timeout after {} seconds", timeout_seconds)
-            }
-            Self::StorageError { operation, message } => {
-                write!(f, "Storage error during {}: {}", operation, message)
-            }
-            Self::Other(msg) => write!(f, "Unexpected error: {}", msg),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FailedPmcId {
-    pub pmcid: String,
-    pub reason: FailureReason,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error_details: Option<String>,
-}
 
 pub struct FiguresOptions {
     pub pmcids: Vec<String>,
@@ -124,107 +25,43 @@ pub struct FiguresOptions {
 pub async fn execute(options: FiguresOptions, ctx: &ClientContext<'_>) -> Result<()> {
     let storage = create_storage_backend(options.output_dir, options.s3_path, options.s3_region)
         .await
-        .context("Failed to create storage backend")?;
+        .map_err(|e| anyhow::anyhow!("Failed to create storage backend: {}", e))?;
 
     let timeout = options.timeout_seconds.unwrap_or(180);
     let client = ctx.pmc_client_with_timeout(Some(timeout));
 
-    let mut failed_pmcids: Vec<FailedPmcId> = Vec::new();
+    let mut processor = BatchProcessor::new(options.pmcids.len())?;
 
-    // Create progress bars
-    let multi_progress = MultiProgress::new();
-    let total_pmcids = options.pmcids.len();
+    processor
+        .run(&options.pmcids, async |multi_progress, pmcid| {
+            process_article(
+                &client,
+                pmcid,
+                storage.as_ref(),
+                options.overwrite,
+                multi_progress,
+            )
+            .await
+        })
+        .await;
 
-    let main_pb = multi_progress.add(ProgressBar::new(total_pmcids as u64));
-    main_pb.set_style(
-        ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} articles ({msg})")
-            .context("Failed to set progress bar style")?
-            .progress_chars("#>-"),
-    );
-    main_pb.set_message("Processing PMC articles");
+    processor.finish();
 
-    // Process each PMCID
-    for pmcid in &options.pmcids {
-        main_pb.set_message(format!("Processing {}", pmcid));
-        debug!(pmcid = %pmcid, "Processing article");
-
-        match process_article_with_progress(
-            &client,
-            pmcid,
-            storage.as_ref(),
-            options.overwrite,
-            &multi_progress,
-        )
-        .await
-        {
-            Ok(_) => {
-                debug!(pmcid = %pmcid, "Successfully processed article");
-                main_pb.set_message(format!("Completed {}", pmcid));
-            }
-            Err(e) => {
-                error!(pmcid = %pmcid, error = %e, "Failed to process article");
-
-                // Determine the failure reason based on the error
-                let (reason, error_details) = categorize_failure_from_figures_error(&e, pmcid);
-
-                failed_pmcids.push(FailedPmcId {
-                    pmcid: pmcid.clone(),
-                    reason,
-                    error_details: Some(error_details),
-                });
-                main_pb.set_message(format!("Failed {}", pmcid));
-                continue;
-            }
-        }
-
-        main_pb.inc(1);
-    }
-
-    main_pb.finish_with_message(format!(
-        "Processed {} articles ({} failed)",
-        total_pmcids,
-        failed_pmcids.len()
-    ));
-
-    if !failed_pmcids.is_empty() {
-        // Save failed PMC IDs to file if output path is specified
-        if let Some(failed_path) = options.failed_output {
-            match save_failed_pmcids_json(&failed_pmcids, &failed_path, storage.as_ref()).await {
-                Ok(_) => {
-                    info!(
-                        path = %failed_path.display(),
-                        count = failed_pmcids.len(),
-                        "Saved failed PMC IDs to JSON file"
-                    );
-                }
-                Err(e) => {
-                    error!(
-                        path = %failed_path.display(),
-                        error = %e,
-                        "Failed to save failed PMC IDs to JSON file"
-                    );
-                }
-            }
-        } else {
-            error!(
-                failed_count = failed_pmcids.len(),
-                failed_pmcids = ?failed_pmcids,
-                "Failed to process some PMC IDs"
-            );
-        }
-    }
-
-    Ok(())
+    report_failures(
+        processor.failures(),
+        options.failed_output,
+        storage.as_ref(),
+    )
+    .await
 }
 
-async fn process_article_with_progress(
+async fn process_article(
     client: &pubmed_client::PmcClient,
     pmcid: &str,
     storage: &dyn StorageBackend,
     overwrite: bool,
     multi_progress: &MultiProgress,
-) -> Result<(), FiguresError> {
+) -> Result<(), BatchItemError> {
     // Check if metadata file already exists and skip early if overwrite is false
     let article_dir_str = pmcid;
     let json_filename = format!("{}_figures_metadata.json", pmcid);
@@ -242,10 +79,8 @@ async fn process_article_with_progress(
 
     // Create a temporary directory for extraction using tempfile crate
     // This ensures automatic cleanup on drop and avoids conflicts
-    let temp_dir_handle = TempDir::new().map_err(|e| FiguresError::Other {
-        pmcid: pmcid.to_string(),
-        source: anyhow::anyhow!(e),
-    })?;
+    let temp_dir_handle = TempDir::new()
+        .map_err(|e| BatchItemError::new(pmcid, FailureKind::Other, e.to_string()))?;
     let temp_dir = temp_dir_handle.path();
 
     // Create progress bar for downloading
@@ -253,10 +88,7 @@ async fn process_article_with_progress(
     download_pb.set_style(
         ProgressStyle::default_spinner()
             .template("{spinner:.green} {msg}")
-            .map_err(|e| FiguresError::Other {
-                pmcid: pmcid.to_string(),
-                source: anyhow::anyhow!(e),
-            })?,
+            .map_err(|e| BatchItemError::new(pmcid, FailureKind::Other, e.to_string()))?,
     );
     download_pb.enable_steady_tick(Duration::from_millis(100));
     download_pb.set_message(format!("Downloading and extracting figures from {}", pmcid));
@@ -273,43 +105,37 @@ async fn process_article_with_progress(
         Err(e) => {
             download_pb.finish_with_message(format!("Failed to download {}", pmcid));
             // Temporary directory will be automatically cleaned up when temp_dir_handle is dropped
-            error!(
-                pmcid = %pmcid,
-                error = %e,
-                "Failed to download TAR archive or extract figures"
-            );
-
-            // Check if it's a timeout error
             let error_str = e.to_string();
-            if error_str.contains("timeout") || error_str.contains("timed out") {
-                return Err(FiguresError::NetworkTimeout {
-                    pmcid: pmcid.to_string(),
-                    timeout_seconds: client.get_tar_client_config().timeout.as_secs(),
-                });
-            }
-
-            return Err(FiguresError::TarDownloadFailed {
-                pmcid: pmcid.to_string(),
-                source: anyhow::anyhow!(e),
-            });
+            let timeout_seconds = client.get_tar_client_config().timeout.as_secs();
+            return Err(BatchItemError::new(
+                pmcid,
+                classify_fetch_error(&error_str, timeout_seconds),
+                format!("TAR download/extraction failed: {:#}", anyhow::anyhow!(e)),
+            ));
         }
     };
 
     if figures.is_empty() {
         // Temporary directory will be automatically cleaned up when temp_dir_handle is dropped
-        return Err(FiguresError::NoFiguresFound {
-            pmcid: pmcid.to_string(),
-        });
+        return Err(BatchItemError::new(
+            pmcid,
+            FailureKind::Empty,
+            "No figures found in article",
+        ));
     }
 
     // Now that we have figures, ensure the storage directory exists
     storage
         .ensure_directory(article_dir_str)
         .await
-        .map_err(|e| FiguresError::StorageError {
-            pmcid: pmcid.to_string(),
-            operation: "ensure_directory".to_string(),
-            source: e,
+        .map_err(|e| {
+            BatchItemError::new(
+                pmcid,
+                FailureKind::StorageError {
+                    operation: "ensure_directory".to_string(),
+                },
+                format!("{:#}", e),
+            )
         })?;
     debug!(directory = %storage.get_full_path(article_dir_str), "Created storage directory");
 
@@ -323,10 +149,7 @@ async fn process_article_with_progress(
     figure_pb.set_style(
         ProgressStyle::default_bar()
             .template("  {spinner:.green} Saving figures [{bar:30.cyan/blue}] {pos}/{len} {msg}")
-            .map_err(|e| FiguresError::Other {
-                pmcid: pmcid.to_string(),
-                source: anyhow::anyhow!(e),
-            })?
+            .map_err(|e| BatchItemError::new(pmcid, FailureKind::Other, e.to_string()))?
             .progress_chars("#>-"),
     );
     figure_pb.set_message(pmcid.to_string());
@@ -409,33 +232,33 @@ async fn process_article_with_progress(
 
     // Save metadata as JSON to storage (always save metadata if we got this far)
     let json_content = serde_json::to_string_pretty(&figure_metadata).map_err(|e| {
-        FiguresError::MetadataSaveFailed {
-            pmcid: pmcid.to_string(),
-            path: json_storage_path.clone(),
-            source: anyhow::anyhow!(e),
-        }
+        BatchItemError::new(
+            pmcid,
+            FailureKind::StorageError {
+                operation: "serialize_metadata".to_string(),
+            },
+            e.to_string(),
+        )
     })?;
 
     storage
         .write_file(&json_storage_path, json_content.as_bytes())
         .await
-        .map_err(|e| FiguresError::MetadataSaveFailed {
-            pmcid: pmcid.to_string(),
-            path: json_storage_path.clone(),
-            source: e,
+        .map_err(|e| {
+            BatchItemError::new(
+                pmcid,
+                FailureKind::StorageError {
+                    operation: "write_metadata".to_string(),
+                },
+                format!("Failed to save metadata to {}: {:#}", json_storage_path, e),
+            )
         })?;
 
-    let metadata_action = if storage
-        .file_exists(&json_storage_path)
-        .await
-        .unwrap_or(false)
-        && overwrite
-    {
-        "Overwritten"
-    } else {
-        "Saved"
-    };
-    debug!(filename = %json_filename, location = %storage.get_full_path(&json_storage_path), "{} metadata", metadata_action);
+    debug!(
+        filename = %json_filename,
+        location = %storage.get_full_path(&json_storage_path),
+        "Saved metadata"
+    );
 
     Ok(())
 }
@@ -446,69 +269,4 @@ struct FigureMetadata {
     figureid: String,
     label: Option<String>,
     caption: Option<String>,
-}
-
-fn categorize_failure_from_figures_error(
-    error: &FiguresError,
-    _pmcid: &str,
-) -> (FailureReason, String) {
-    let error_str = error.to_string();
-    let error_chain = format!("{:#}", error); // Include full error chain for debugging
-
-    let reason = match error {
-        FiguresError::TarDownloadFailed { .. } => {
-            let is_timeout = error_str.contains("timeout") || error_str.contains("timed out");
-            let is_network = error_str.contains("network") || error_str.contains("connection");
-            FailureReason::TarDownloadFailed {
-                message: error_str.clone(),
-                is_timeout,
-                is_network_error: is_network,
-            }
-        }
-        FiguresError::NoFiguresFound { .. } => FailureReason::NoFiguresFound,
-        FiguresError::MetadataSaveFailed { path, .. } => FailureReason::MetadataSaveFailed(
-            format!("Failed to save metadata to {}: {}", path, error_str),
-        ),
-        FiguresError::NetworkTimeout {
-            timeout_seconds, ..
-        } => FailureReason::NetworkTimeout {
-            timeout_seconds: *timeout_seconds,
-        },
-        FiguresError::StorageError { operation, .. } => FailureReason::StorageError {
-            operation: operation.clone(),
-            message: error_str.clone(),
-        },
-        FiguresError::Other { .. } => FailureReason::Other(error_str.clone()),
-    };
-
-    (reason, error_chain)
-}
-
-async fn save_failed_pmcids_json(
-    failed_pmcids: &[FailedPmcId],
-    path: &Path,
-    storage: &dyn StorageBackend,
-) -> Result<()> {
-    // Convert to JSON with pretty formatting
-    let json_content = serde_json::to_string_pretty(failed_pmcids)?;
-
-    // Get just the filename from the path
-    let filename = path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| anyhow::anyhow!("Invalid failed output path"))?;
-
-    // Ensure the filename has .json extension
-    let json_filename = if !filename.ends_with(".json") {
-        format!("{}.json", filename.trim_end_matches('.'))
-    } else {
-        filename.to_string()
-    };
-
-    // Write to storage
-    storage
-        .write_file(&json_filename, json_content.as_bytes())
-        .await?;
-
-    Ok(())
 }

--- a/pubmed-cli/src/commands/markdown.rs
+++ b/pubmed-cli/src/commands/markdown.rs
@@ -1,10 +1,16 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Args;
 use pubmed_client::pmc::{MarkdownConfig, PmcMarkdownConverter};
+use tempfile::TempDir;
 
 use super::ClientContext;
+use crate::commands::batch::{
+    BatchItemError, BatchProcessor, FailureKind, classify_fetch_error, report_failures,
+};
+use crate::commands::storage::{StorageBackend, create_storage_backend};
 
 #[derive(Args, Debug)]
 pub struct Markdown {
@@ -12,9 +18,21 @@ pub struct Markdown {
     #[arg(required = true)]
     pmcids: Vec<String>,
 
-    /// Output directory for markdown files
-    #[arg(short, long, default_value = ".")]
-    output_dir: PathBuf,
+    /// Output directory for markdown files (local storage)
+    #[arg(short, long, conflicts_with = "s3_path")]
+    output_dir: Option<PathBuf>,
+
+    /// S3 path for markdown files (e.g., s3://bucket/prefix)
+    #[arg(long, conflicts_with = "output_dir")]
+    s3_path: Option<String>,
+
+    /// AWS region for S3 (optional, uses default AWS config if not specified)
+    #[arg(long, requires = "s3_path")]
+    s3_region: Option<String>,
+
+    /// Path to save failed PMC IDs (if not specified, failures are logged only)
+    #[arg(short, long)]
+    failed_output: Option<PathBuf>,
 
     /// Download and embed figures in the markdown
     #[arg(long)]
@@ -27,29 +45,49 @@ pub struct Markdown {
 
 impl Markdown {
     pub async fn execute(&self, ctx: &ClientContext<'_>) -> Result<()> {
+        // Default to the current directory when no explicit destination is given.
+        let output_dir = match (&self.output_dir, &self.s3_path) {
+            (None, None) => Some(PathBuf::from(".")),
+            (dir, _) => dir.clone(),
+        };
+        let storage =
+            create_storage_backend(output_dir, self.s3_path.clone(), self.s3_region.clone())
+                .await?;
+
         let client = ctx.pmc_client();
 
-        tokio::fs::create_dir_all(&self.output_dir).await?;
+        let mut processor = BatchProcessor::new(self.pmcids.len())?;
+        processor
+            .run(&self.pmcids, async |_multi_progress, pmcid| {
+                self.process_article(&client, pmcid, storage.as_ref(), ctx)
+                    .await
+            })
+            .await;
+        processor.finish();
 
-        for pmcid in &self.pmcids {
-            tracing::info!(pmcid = %pmcid, "Processing article");
-
-            match self.process_article(&client, pmcid, ctx).await {
-                Ok(_) => tracing::info!(pmcid = %pmcid, "Successfully converted to markdown"),
-                Err(e) => tracing::error!(pmcid = %pmcid, error = %e, "Failed to process article"),
-            }
-        }
-
-        Ok(())
+        report_failures(
+            processor.failures(),
+            self.failed_output.clone(),
+            storage.as_ref(),
+        )
+        .await
     }
 
     async fn process_article(
         &self,
         client: &pubmed_client::pmc::PmcClient,
         pmcid: &str,
+        storage: &dyn StorageBackend,
         ctx: &ClientContext<'_>,
-    ) -> Result<()> {
-        let article = client.fetch_full_text(pmcid).await?;
+    ) -> Result<(), BatchItemError> {
+        let article = client.fetch_full_text(pmcid).await.map_err(|e| {
+            let timeout_seconds = client.get_pmc_config().timeout.as_secs();
+            BatchItemError::new(
+                pmcid,
+                classify_fetch_error(&e.to_string(), timeout_seconds),
+                format!("Failed to fetch article: {:#}", anyhow::anyhow!(e)),
+            )
+        })?;
 
         let mut config = MarkdownConfig {
             metadata: pubmed_client::pmc::MetadataOptions {
@@ -60,36 +98,9 @@ impl Markdown {
         };
 
         let figure_paths = if self.with_figures {
-            let article_dir = self.output_dir.join(pmcid);
-            let figures_dir = article_dir.join("figures");
-            tokio::fs::create_dir_all(&figures_dir).await?;
-
-            let tar_client = pubmed_client::pmc::PmcTarClient::new(ctx.build_config());
-            let extracted_figures = tar_client
-                .extract_figures_with_captions(pmcid, &figures_dir)
-                .await?;
-
-            let mut figure_paths = std::collections::HashMap::new();
-            for fig in extracted_figures {
-                let file_path = &fig.extracted_file_path;
-                let path = std::path::Path::new(file_path);
-
-                if let Ok(relative_from_output) = path.strip_prefix(&self.output_dir) {
-                    let relative_path = format!("./{}", relative_from_output.to_string_lossy());
-                    figure_paths.insert(fig.figure.id.clone(), relative_path);
-                } else {
-                    let file_name = path
-                        .file_name()
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                        .to_string();
-                    let relative_path = format!("./{}/figures/{}/{}", pmcid, pmcid, file_name);
-                    figure_paths.insert(fig.figure.id.clone(), relative_path);
-                }
-            }
-
+            let paths = self.extract_figures(client, pmcid, storage, ctx).await?;
             config.figures.include_local_figures = true;
-            Some(figure_paths)
+            Some(paths)
         } else {
             None
         };
@@ -97,9 +108,83 @@ impl Markdown {
         let converter = PmcMarkdownConverter::with_config(config);
         let markdown = converter.convert_with_figures(&article, figure_paths.as_ref());
 
-        let output_file = self.output_dir.join(format!("{}.md", pmcid));
-        tokio::fs::write(&output_file, markdown).await?;
+        let output_file = format!("{}.md", pmcid);
+        storage
+            .write_file(&output_file, markdown.as_bytes())
+            .await
+            .map_err(|e| {
+                BatchItemError::new(
+                    pmcid,
+                    FailureKind::StorageError {
+                        operation: "write_markdown".to_string(),
+                    },
+                    format!("{:#}", e),
+                )
+            })?;
 
         Ok(())
+    }
+
+    /// Download figures into the storage backend and return a map from figure ID
+    /// to the markdown-relative path used to reference it.
+    async fn extract_figures(
+        &self,
+        client: &pubmed_client::pmc::PmcClient,
+        pmcid: &str,
+        storage: &dyn StorageBackend,
+        ctx: &ClientContext<'_>,
+    ) -> Result<HashMap<String, String>, BatchItemError> {
+        let storage_err = |op: &str, e: anyhow::Error| {
+            BatchItemError::new(
+                pmcid,
+                FailureKind::StorageError {
+                    operation: op.to_string(),
+                },
+                format!("{:#}", e),
+            )
+        };
+
+        let temp_dir = TempDir::new()
+            .map_err(|e| BatchItemError::new(pmcid, FailureKind::Other, e.to_string()))?;
+
+        let tar_client = pubmed_client::pmc::PmcTarClient::new(ctx.build_config());
+        let extracted_figures = tar_client
+            .extract_figures_with_captions(pmcid, temp_dir.path())
+            .await
+            .map_err(|e| {
+                let timeout_seconds = client.get_tar_client_config().timeout.as_secs();
+                BatchItemError::new(
+                    pmcid,
+                    classify_fetch_error(&e.to_string(), timeout_seconds),
+                    format!("Failed to extract figures: {:#}", anyhow::anyhow!(e)),
+                )
+            })?;
+
+        let figures_dir = format!("{}/figures", pmcid);
+        storage
+            .ensure_directory(&figures_dir)
+            .await
+            .map_err(|e| storage_err("ensure_directory", e))?;
+
+        let mut figure_paths = HashMap::new();
+        for fig in extracted_figures {
+            let src = std::path::Path::new(&fig.extracted_file_path);
+            let file_name = src
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let storage_path = format!("{}/{}", figures_dir, file_name);
+
+            storage
+                .copy_file(src, &storage_path)
+                .await
+                .map_err(|e| storage_err("copy_figure", e))?;
+
+            let relative_path = format!("./{}/figures/{}", pmcid, file_name);
+            figure_paths.insert(fig.figure.id.clone(), relative_path);
+        }
+
+        Ok(figure_paths)
     }
 }

--- a/pubmed-cli/src/commands/metadata.rs
+++ b/pubmed-cli/src/commands/metadata.rs
@@ -1,239 +1,105 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Duration;
+
 use anyhow::{Context as _, Result};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::path::{Path, PathBuf};
-use std::time::Duration;
-use thiserror::Error;
-use tokio::io::AsyncWriteExt;
-use tracing::{debug, error, info};
+use tracing::info;
 
 use crate::commands::ClientContext;
-
-#[derive(Error, Debug)]
-pub enum MetadataError {
-    #[error("Failed to fetch metadata for PMC ID {pmcid}: {source}")]
-    FetchFailed {
-        pmcid: String,
-        #[source]
-        source: anyhow::Error,
-    },
-
-    #[error("Article not found: {pmcid}")]
-    ArticleNotFound { pmcid: String },
-
-    #[error("Network timeout while processing {pmcid} (timeout: {timeout_seconds}s)")]
-    NetworkTimeout { pmcid: String, timeout_seconds: u64 },
-
-    #[error("Unexpected error processing {pmcid}: {source}")]
-    Other {
-        pmcid: String,
-        #[source]
-        source: anyhow::Error,
-    },
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum FailureReason {
-    FetchFailed {
-        message: String,
-        is_timeout: bool,
-        is_network_error: bool,
-    },
-    ArticleNotFound,
-    NetworkTimeout {
-        timeout_seconds: u64,
-    },
-    Other(String),
-}
-
-impl fmt::Display for FailureReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::FetchFailed {
-                message,
-                is_timeout,
-                is_network_error,
-            } => {
-                write!(
-                    f,
-                    "Metadata fetch failed: {}{}{}",
-                    message,
-                    if *is_timeout { " (timeout)" } else { "" },
-                    if *is_network_error {
-                        " (network error)"
-                    } else {
-                        ""
-                    }
-                )
-            }
-            Self::ArticleNotFound => write!(f, "Article not found"),
-            Self::NetworkTimeout { timeout_seconds } => {
-                write!(f, "Network timeout after {} seconds", timeout_seconds)
-            }
-            Self::Other(msg) => write!(f, "Unexpected error: {}", msg),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FailedPmcId {
-    pub pmcid: String,
-    pub reason: FailureReason,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error_details: Option<String>,
-}
+use crate::commands::batch::{
+    BatchItemError, BatchProcessor, FailureKind, classify_fetch_error, report_failures,
+};
+use crate::commands::storage::create_file_storage;
 
 pub struct MetadataOptions {
     pub pmcids: Vec<String>,
     pub output_file: Option<PathBuf>,
+    pub s3_path: Option<String>,
+    pub s3_region: Option<String>,
     pub failed_output: Option<PathBuf>,
     pub timeout_seconds: Option<u64>,
     pub append: bool,
 }
 
 pub async fn execute(options: MetadataOptions, ctx: &ClientContext<'_>) -> Result<()> {
-    let output_path = options
-        .output_file
-        .unwrap_or_else(|| PathBuf::from("metadata.jsonl"));
+    let (storage, output_key) = create_file_storage(
+        options.output_file,
+        options.s3_path,
+        options.s3_region,
+        "metadata.jsonl",
+    )
+    .await
+    .context("Failed to create storage backend")?;
 
     let timeout = options.timeout_seconds.unwrap_or(60);
     let client = ctx.pmc_client_with_timeout(Some(timeout));
 
-    let mut failed_pmcids: Vec<FailedPmcId> = Vec::new();
+    let mut processor = BatchProcessor::new(options.pmcids.len())?;
 
-    // Create progress bars
-    let multi_progress = MultiProgress::new();
-    let total_pmcids = options.pmcids.len();
+    // Successful metadata lines are accumulated here, then written in one shot so
+    // the same code path works for both local and S3 storage backends.
+    let buffer: Mutex<Vec<u8>> = Mutex::new(Vec::new());
 
-    let main_pb = multi_progress.add(ProgressBar::new(total_pmcids as u64));
-    main_pb.set_style(
-        ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} articles ({msg})")
-            .context("Failed to set progress bar style")?
-            .progress_chars("#>-"),
-    );
-    main_pb.set_message("Processing PMC articles");
+    processor
+        .run(&options.pmcids, async |multi_progress, pmcid| {
+            let metadata = fetch_article_metadata(&client, pmcid, multi_progress).await?;
+            let json_line = serde_json::to_string(&metadata)
+                .map_err(|e| BatchItemError::new(pmcid, FailureKind::Other, e.to_string()))?;
+            let mut buf = buffer.lock().unwrap_or_else(|e| e.into_inner());
+            buf.extend_from_slice(json_line.as_bytes());
+            buf.push(b'\n');
+            Ok(())
+        })
+        .await;
 
-    // Open output file for writing (append mode if specified)
-    let mut output_file = if options.append && output_path.exists() {
-        tokio::fs::OpenOptions::new()
-            .append(true)
-            .open(&output_path)
-            .await
-            .context("Failed to open output file for appending")?
-    } else {
-        tokio::fs::File::create(&output_path)
-            .await
-            .context("Failed to create output file")?
-    };
+    processor.finish();
 
-    // Process each PMCID
-    for pmcid in &options.pmcids {
-        main_pb.set_message(format!("Processing {}", pmcid));
-        debug!(pmcid = %pmcid, "Processing article metadata");
+    let mut content = buffer.into_inner().unwrap_or_else(|e| e.into_inner());
 
-        match fetch_article_metadata(&client, pmcid, &multi_progress).await {
-            Ok(metadata) => {
-                // Write metadata as a single line of JSON
-                let json_line =
-                    serde_json::to_string(&metadata).context("Failed to serialize metadata")?;
-
-                output_file
-                    .write_all(json_line.as_bytes())
-                    .await
-                    .context("Failed to write metadata to file")?;
-                output_file
-                    .write_all(b"\n")
-                    .await
-                    .context("Failed to write newline")?;
-
-                debug!(pmcid = %pmcid, "Successfully processed article metadata");
-                main_pb.set_message(format!("Completed {}", pmcid));
-            }
-            Err(e) => {
-                error!(pmcid = %pmcid, error = %e, "Failed to process article metadata");
-
-                // Determine the failure reason based on the error
-                let (reason, error_details) = categorize_failure_from_metadata_error(&e, pmcid);
-
-                failed_pmcids.push(FailedPmcId {
-                    pmcid: pmcid.clone(),
-                    reason,
-                    error_details: Some(error_details),
-                });
-                main_pb.set_message(format!("Failed {}", pmcid));
-                continue;
-            }
+    // Append mode: prepend any existing content before writing the combined file.
+    if options.append
+        && let Some(mut existing) = storage.read_file(&output_key).await.unwrap_or(None)
+    {
+        if !existing.is_empty() && !existing.ends_with(b"\n") {
+            existing.push(b'\n');
         }
-
-        main_pb.inc(1);
+        existing.append(&mut content);
+        content = existing;
     }
 
-    // Ensure all data is written
-    output_file
-        .flush()
+    storage
+        .write_file(&output_key, &content)
         .await
-        .context("Failed to flush output file")?;
+        .context("Failed to write metadata output")?;
 
-    main_pb.finish_with_message(format!(
-        "Processed {} articles ({} failed)",
-        total_pmcids,
-        failed_pmcids.len()
-    ));
-
+    let succeeded = options.pmcids.len() - processor.failures().len();
     info!(
-        path = %output_path.display(),
-        count = options.pmcids.len() - failed_pmcids.len(),
+        path = %storage.get_full_path(&output_key),
+        count = succeeded,
         "Saved metadata to JSONL file"
     );
 
-    if !failed_pmcids.is_empty() {
-        // Save failed PMC IDs to file if output path is specified
-        if let Some(failed_path) = options.failed_output {
-            match save_failed_pmcids_json(&failed_pmcids, &failed_path).await {
-                Ok(_) => {
-                    info!(
-                        path = %failed_path.display(),
-                        count = failed_pmcids.len(),
-                        "Saved failed PMC IDs to JSON file"
-                    );
-                }
-                Err(e) => {
-                    error!(
-                        path = %failed_path.display(),
-                        error = %e,
-                        "Failed to save failed PMC IDs to JSON file"
-                    );
-                }
-            }
-        } else {
-            error!(
-                failed_count = failed_pmcids.len(),
-                failed_pmcids = ?failed_pmcids,
-                "Failed to process some PMC IDs"
-            );
-        }
-    }
-
-    Ok(())
+    report_failures(
+        processor.failures(),
+        options.failed_output,
+        storage.as_ref(),
+    )
+    .await
 }
 
 async fn fetch_article_metadata(
     client: &pubmed_client::PmcClient,
     pmcid: &str,
     multi_progress: &MultiProgress,
-) -> Result<ArticleMetadata, MetadataError> {
+) -> Result<ArticleMetadata, BatchItemError> {
     // Create progress bar for downloading
     let download_pb = multi_progress.add(ProgressBar::new_spinner());
     download_pb.set_style(
         ProgressStyle::default_spinner()
             .template("{spinner:.green} {msg}")
-            .map_err(|e| MetadataError::Other {
-                pmcid: pmcid.to_string(),
-                source: anyhow::anyhow!(e),
-            })?,
+            .map_err(|e| BatchItemError::new(pmcid, FailureKind::Other, e.to_string()))?,
     );
     download_pb.enable_steady_tick(Duration::from_millis(100));
     download_pb.set_message(format!("Fetching metadata for {}", pmcid));
@@ -246,32 +112,13 @@ async fn fetch_article_metadata(
         }
         Err(e) => {
             download_pb.finish_with_message(format!("Failed to fetch {}", pmcid));
-            error!(
-                pmcid = %pmcid,
-                error = %e,
-                "Failed to fetch PMC article metadata"
-            );
-
-            // Check if it's a timeout error
             let error_str = e.to_string();
-            if error_str.contains("timeout") || error_str.contains("timed out") {
-                return Err(MetadataError::NetworkTimeout {
-                    pmcid: pmcid.to_string(),
-                    timeout_seconds: client.get_pmc_config().timeout.as_secs(),
-                });
-            }
-
-            // Check if article not found
-            if error_str.contains("not found") || error_str.contains("404") {
-                return Err(MetadataError::ArticleNotFound {
-                    pmcid: pmcid.to_string(),
-                });
-            }
-
-            return Err(MetadataError::FetchFailed {
-                pmcid: pmcid.to_string(),
-                source: anyhow::anyhow!(e),
-            });
+            let timeout_seconds = client.get_pmc_config().timeout.as_secs();
+            return Err(BatchItemError::new(
+                pmcid,
+                classify_fetch_error(&error_str, timeout_seconds),
+                format!("Metadata fetch failed: {:#}", anyhow::anyhow!(e)),
+            ));
         }
     };
 
@@ -325,45 +172,4 @@ struct ArticleMetadata {
     keywords: Vec<String>,
     funding: Vec<pubmed_client::pmc::FundingInfo>,
     references: Vec<pubmed_client::pmc::Reference>,
-}
-
-fn categorize_failure_from_metadata_error(
-    error: &MetadataError,
-    _pmcid: &str,
-) -> (FailureReason, String) {
-    let error_str = error.to_string();
-    let error_chain = format!("{:#}", error); // Include full error chain for debugging
-
-    let reason = match error {
-        MetadataError::FetchFailed { .. } => {
-            let is_timeout = error_str.contains("timeout") || error_str.contains("timed out");
-            let is_network = error_str.contains("network") || error_str.contains("connection");
-            FailureReason::FetchFailed {
-                message: error_str.clone(),
-                is_timeout,
-                is_network_error: is_network,
-            }
-        }
-        MetadataError::ArticleNotFound { .. } => FailureReason::ArticleNotFound,
-        MetadataError::NetworkTimeout {
-            timeout_seconds, ..
-        } => FailureReason::NetworkTimeout {
-            timeout_seconds: *timeout_seconds,
-        },
-        MetadataError::Other { .. } => FailureReason::Other(error_str.clone()),
-    };
-
-    (reason, error_chain)
-}
-
-async fn save_failed_pmcids_json(failed_pmcids: &[FailedPmcId], path: &Path) -> Result<()> {
-    // Convert to JSON with pretty formatting
-    let json_content = serde_json::to_string_pretty(failed_pmcids)?;
-
-    // Write to file
-    tokio::fs::write(path, json_content)
-        .await
-        .context("Failed to write failed PMC IDs to file")?;
-
-    Ok(())
 }

--- a/pubmed-cli/src/commands/mod.rs
+++ b/pubmed-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod batch;
 pub mod citations;
 pub mod citmatch;
 pub mod convert;

--- a/pubmed-cli/src/commands/storage.rs
+++ b/pubmed-cli/src/commands/storage.rs
@@ -12,6 +12,8 @@ pub trait StorageBackend: Send + Sync {
     async fn copy_file(&self, source: &Path, dest_path: &str) -> Result<()>;
     async fn ensure_directory(&self, path: &str) -> Result<()>;
     async fn file_exists(&self, path: &str) -> Result<bool>;
+    /// Read a file's contents, returning `None` if it does not exist.
+    async fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>>;
     fn get_full_path(&self, relative_path: &str) -> String;
 }
 
@@ -61,6 +63,15 @@ impl StorageBackend for LocalStorage {
     async fn file_exists(&self, path: &str) -> Result<bool> {
         let full_path = self.base_path.join(path);
         Ok(full_path.exists())
+    }
+
+    async fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        let full_path = self.base_path.join(path);
+        match fs::read(&full_path).await {
+            Ok(content) => Ok(Some(content)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     fn get_full_path(&self, relative_path: &str) -> String {
@@ -156,6 +167,36 @@ impl StorageBackend for S3Storage {
         }
     }
 
+    async fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        let key = self.get_s3_key(path);
+
+        match self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+        {
+            Ok(output) => {
+                let bytes = output
+                    .body
+                    .collect()
+                    .await
+                    .map_err(|e| anyhow!("Failed to read S3 object body: {}", e))?;
+                Ok(Some(bytes.into_bytes().to_vec()))
+            }
+            Err(e) => {
+                if let aws_sdk_s3::error::SdkError::ServiceError(ref service_err) = e
+                    && service_err.err().is_no_such_key()
+                {
+                    return Ok(None);
+                }
+                Err(anyhow!("Failed to read S3 object: {}", e))
+            }
+        }
+    }
+
     fn get_full_path(&self, relative_path: &str) -> String {
         let key = self.get_s3_key(relative_path);
         format!("s3://{}/{}", self.bucket, key)
@@ -211,6 +252,75 @@ pub async fn create_storage_backend(
     }
 }
 
+/// Build a storage backend plus the relative key for a command that writes a
+/// single named file (e.g. `metadata.jsonl`, `citations.bib`).
+///
+/// - Local: `output` (default `default_filename`) is split into a parent
+///   directory (the storage root, created if needed) and a filename (the key).
+/// - S3: `s3_path` must be the full object path, e.g.
+///   `s3://bucket/prefix/metadata.jsonl`; the last path segment becomes the key.
+///
+/// Exactly one of `output` / `s3_path` may be set.
+pub async fn create_file_storage(
+    output: Option<PathBuf>,
+    s3_path: Option<String>,
+    s3_region: Option<String>,
+    default_filename: &str,
+) -> Result<(Box<dyn StorageBackend>, String)> {
+    match (output, s3_path) {
+        (Some(_), Some(_)) => Err(anyhow!(
+            "Cannot specify both --output and --s3-path. Choose one storage location."
+        )),
+        (output, None) => {
+            let path = output.unwrap_or_else(|| PathBuf::from(default_filename));
+            let filename = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .ok_or_else(|| anyhow!("Invalid output path: {}", path.display()))?
+                .to_string();
+            let base = path
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from("."));
+            fs::create_dir_all(&base).await?;
+            info!("Using local storage: {}", base.display());
+            Ok((Box::new(LocalStorage::new(base)), filename))
+        }
+        (None, Some(s3)) => {
+            let (prefix_path, filename) = split_s3_object_path(&s3)?;
+            info!("Using S3 storage: {}", s3);
+            let storage = S3Storage::new(&prefix_path, s3_region).await?;
+            Ok((Box::new(storage), filename))
+        }
+    }
+}
+
+/// Split a full S3 object path into a prefix path (`s3://bucket/prefix`) and a
+/// filename (the final segment).
+fn split_s3_object_path(s3_path: &str) -> Result<(String, String)> {
+    if !s3_path.starts_with("s3://") {
+        return Err(anyhow!(
+            "Invalid S3 path. Must start with 's3://'. Got: {}",
+            s3_path
+        ));
+    }
+
+    let trimmed = s3_path.trim_end_matches('/');
+    let (prefix_path, filename) = trimmed
+        .rsplit_once('/')
+        .filter(|(prefix, name)| *prefix != "s3:/" && !name.is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "Invalid S3 object path. Must include a bucket and object key, e.g. \
+                 's3://bucket/path/file.ext'. Got: {}",
+                s3_path
+            )
+        })?;
+
+    Ok((prefix_path.to_string(), filename.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,6 +346,64 @@ mod tests {
         );
         assert!(parse_s3_path("bucket/prefix").is_err());
         assert!(parse_s3_path("s3://").is_err());
+    }
+
+    #[test]
+    fn test_split_s3_object_path() {
+        assert_eq!(
+            split_s3_object_path("s3://bucket/file.jsonl").unwrap(),
+            ("s3://bucket".to_string(), "file.jsonl".to_string())
+        );
+        assert_eq!(
+            split_s3_object_path("s3://bucket/a/b/file.jsonl").unwrap(),
+            ("s3://bucket/a/b".to_string(), "file.jsonl".to_string())
+        );
+        // Missing object key
+        assert!(split_s3_object_path("s3://bucket").is_err());
+        assert!(split_s3_object_path("s3://bucket/").is_err());
+        // Missing scheme
+        assert!(split_s3_object_path("bucket/file.jsonl").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_file_storage_local_default() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("metadata.jsonl");
+
+        let (storage, key) = create_file_storage(Some(path.clone()), None, None, "metadata.jsonl")
+            .await
+            .unwrap();
+        assert_eq!(key, "metadata.jsonl");
+
+        storage.write_file(&key, b"line\n").await.unwrap();
+        assert!(path.exists());
+        assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), "line\n");
+    }
+
+    #[tokio::test]
+    async fn test_create_file_storage_conflict() {
+        let result = create_file_storage(
+            Some(PathBuf::from("out.jsonl")),
+            Some("s3://bucket/out.jsonl".to_string()),
+            None,
+            "metadata.jsonl",
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_local_storage_read_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = LocalStorage::new(temp_dir.path().to_path_buf());
+
+        assert!(storage.read_file("missing.txt").await.unwrap().is_none());
+
+        storage.write_file("present.txt", b"hello").await.unwrap();
+        assert_eq!(
+            storage.read_file("present.txt").await.unwrap(),
+            Some(b"hello".to_vec())
+        );
     }
 
     #[test]

--- a/pubmed-cli/src/main.rs
+++ b/pubmed-cli/src/main.rs
@@ -79,9 +79,15 @@ enum Commands {
     Metadata {
         /// PMC ID(s) to process (e.g., PMC7906746 or 7906746)
         pmcids: Vec<String>,
-        /// Output JSONL file path (default: metadata.jsonl)
-        #[arg(short, long)]
+        /// Output JSONL file path (default: metadata.jsonl, local storage)
+        #[arg(short, long, conflicts_with = "s3_path")]
         output: Option<PathBuf>,
+        /// S3 object path for the JSONL output (e.g., s3://bucket/prefix/metadata.jsonl)
+        #[arg(long, conflicts_with = "output")]
+        s3_path: Option<String>,
+        /// AWS region for S3 (optional, uses default AWS config if not specified)
+        #[arg(long, requires = "s3_path")]
+        s3_region: Option<String>,
         /// Path to save failed PMC IDs (if not specified, failures are logged only)
         #[arg(short, long)]
         failed_output: Option<PathBuf>,
@@ -161,6 +167,8 @@ async fn main() -> Result<()> {
         Commands::Metadata {
             pmcids,
             output,
+            s3_path,
+            s3_region,
             failed_output,
             timeout,
             append,
@@ -168,6 +176,8 @@ async fn main() -> Result<()> {
             let options = commands::metadata::MetadataOptions {
                 pmcids: pmcids.clone(),
                 output_file: output.clone(),
+                s3_path: s3_path.clone(),
+                s3_region: s3_region.clone(),
                 failed_output: failed_output.clone(),
                 timeout_seconds: *timeout,
                 append: *append,


### PR DESCRIPTION
## Summary

Extract common batch processing logic from `figures` and `metadata` commands into a new shared `batch` module. This eliminates code duplication and establishes a consistent pattern for all batch CLI commands (figures, metadata, markdown, etc.) to follow.

## Key Changes

- **New `batch` module** (`pubmed-cli/src/commands/batch.rs`):
  - `BatchProcessor` struct to manage progress bars and failure collection
  - `BatchItemError` and `FailureKind` enum for uniform error categorization across commands
  - `classify_fetch_error()` helper to map error strings to failure kinds (timeout, not-found, network, etc.)
  - `report_failures()` function to serialize and save failures to JSON (local or S3)
  - Comprehensive unit tests for error classification and filename handling

- **Refactored `figures` command**:
  - Remove ~100 lines of error types and failure handling
  - Use `BatchProcessor::run()` to drive the main loop
  - Replace custom error types with `BatchItemError`
  - Simplify error handling via `classify_fetch_error()`

- **Refactored `metadata` command**:
  - Remove ~100 lines of error types and failure handling
  - Use `BatchProcessor::run()` to drive the main loop
  - Introduce `create_file_storage()` helper for single-file output (local or S3)
  - Accumulate successful metadata in a buffer, write once at the end
  - Support append mode by reading existing file before writing combined content

- **Updated `markdown` command**:
  - Adopt `BatchProcessor` for consistent progress reporting
  - Add S3 support via `--s3-path` and `--s3-region` flags
  - Add `--failed-output` flag for failure reporting
  - Refactor figure extraction into a separate method

- **Enhanced `storage` module**:
  - Add `read_file()` method to `StorageBackend` trait (returns `Option<Vec<u8>>`)
  - Implement for both `LocalStorage` and `S3Storage`
  - New `create_file_storage()` helper to build storage + key for single-file commands
  - New `split_s3_object_path()` helper to parse S3 URIs

- **Updated `export` command**:
  - Use `create_file_storage()` for consistent output handling
  - Add S3 support via `--s3-path` and `--s3-region` flags

- **Updated CLI argument parsing** (`main.rs`):
  - Add S3 options to `metadata` command
  - Ensure `--output` and `--s3-path` are mutually exclusive

## Implementation Details

- **Error categorization**: `classify_fetch_error()` inspects error strings for timeout, not-found, network, and generic fetch failures. This single function replaces duplicated logic across commands.
- **Progress bar management**: `BatchProcessor` owns the `MultiProgress` and main progress bar, simplifying the per-command loop.
- **Failure collection**: Failures are accumulated in `BatchProcessor` and reported uniformly via `report_failures()`, which handles both local file writes and S3 uploads.
- **File storage abstraction**: `create_file_storage()` unifies the logic for determining output location (local directory + filename, or S3 object path) and returns both the storage backend and the relative key.
- **Append mode**: The metadata command now reads existing content before writing, enabling safe append operations on both local and S3 backends.

This refactoring improves maintainability, reduces duplication, and establishes a consistent pattern for future batch commands.

https://claude.ai/code/session_014NZgekP8c6J1dny5KmNmiG