### PR TITLE
refactor(client): extract shared batch-fetch and elink collectors

### DIFF
--- a/pubmed-client/src/pubmed/client/elink.rs
+++ b/pubmed-client/src/pubmed/client/elink.rs
@@ -43,25 +43,8 @@ impl PubMedClient {
 
         let elink_response = self.elink_request(pmids, "pubmed", "pubmed_pubmed").await?;
 
-        let mut all_related_pmids = Vec::new();
-
-        for linkset in elink_response.linksets {
-            if let Some(linkset_dbs) = linkset.linkset_dbs {
-                for linkset_db in linkset_dbs {
-                    if linkset_db.link_name == "pubmed_pubmed" {
-                        for link_id in linkset_db.links {
-                            if let Ok(pmid) = link_id.parse::<u32>() {
-                                all_related_pmids.push(pmid);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Remove duplicates and original PMIDs
-        all_related_pmids.sort_unstable();
-        all_related_pmids.dedup();
+        let mut all_related_pmids = Self::collect_linked_pmids(elink_response, "pubmed_pubmed");
+        // Drop the original PMIDs from their own related set
         all_related_pmids.retain(|&pmid| !pmids.contains(&pmid));
 
         info!(
@@ -194,25 +177,7 @@ impl PubMedClient {
             .elink_request(pmids, "pubmed", "pubmed_pubmed_citedin")
             .await?;
 
-        let mut citing_pmids = Vec::new();
-
-        for linkset in elink_response.linksets {
-            if let Some(linkset_dbs) = linkset.linkset_dbs {
-                for linkset_db in linkset_dbs {
-                    if linkset_db.link_name == "pubmed_pubmed_citedin" {
-                        for link_id in linkset_db.links {
-                            if let Ok(pmid) = link_id.parse::<u32>() {
-                                citing_pmids.push(pmid);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Remove duplicates
-        citing_pmids.sort_unstable();
-        citing_pmids.dedup();
+        let citing_pmids = Self::collect_linked_pmids(elink_response, "pubmed_pubmed_citedin");
 
         info!(
             source_count = pmids.len(),
@@ -225,6 +190,34 @@ impl PubMedClient {
             citing_pmids,
             link_type: "pubmed_pubmed_citedin".to_string(),
         })
+    }
+
+    /// Collect deduplicated u32 PMIDs from an ELink response for a given link name.
+    ///
+    /// Walks `linksets → linkset_dbs → links`, keeping only entries whose
+    /// `link_name` matches, parsing each link ID to `u32`, then sorting and
+    /// deduplicating the result. Shared by `get_related_articles` and
+    /// `get_citations`, which differ only in the link name and result wrapper.
+    fn collect_linked_pmids(response: ELinkResponse, link_name: &str) -> Vec<u32> {
+        let mut pmids = Vec::new();
+
+        for linkset in response.linksets {
+            if let Some(linkset_dbs) = linkset.linkset_dbs {
+                for linkset_db in linkset_dbs {
+                    if linkset_db.link_name == link_name {
+                        for link_id in linkset_db.links {
+                            if let Ok(pmid) = link_id.parse::<u32>() {
+                                pmids.push(pmid);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        pmids.sort_unstable();
+        pmids.dedup();
+        pmids
     }
 
     /// Internal helper method for ELink API requests

--- a/pubmed-client/src/pubmed/client/mod.rs
+++ b/pubmed-client/src/pubmed/client/mod.rs
@@ -363,6 +363,31 @@ impl PubMedClient {
     /// ```
     #[instrument(skip(self), fields(pmids_count = pmids.len()))]
     pub async fn fetch_articles(&self, pmids: &[&str]) -> Result<Vec<PubMedArticle>> {
+        self.batch_fetch_pmids(
+            pmids,
+            "efetch.fcgi",
+            &[("retmode", "xml"), ("rettype", "abstract")],
+            |xml| Ok(parse_articles_from_xml(xml)?),
+        )
+        .await
+    }
+
+    /// Fetch records for many PMIDs by chunking them into NCBI-sized batches.
+    ///
+    /// Validates every PMID upfront, then splits the request into batches of up to
+    /// 200 IDs (per NCBI guidance), issues one E-utilities call per batch against
+    /// `endpoint` (with `extra_params` appended to the shared `db`/`id` pair), and
+    /// parses each response body with `parse_fn`. Empty response bodies are skipped.
+    pub(crate) async fn batch_fetch_pmids<T, F>(
+        &self,
+        pmids: &[&str],
+        endpoint: &str,
+        extra_params: &[(&str, &str)],
+        parse_fn: F,
+    ) -> Result<Vec<T>>
+    where
+        F: Fn(&str) -> Result<Vec<T>>,
+    {
         if pmids.is_empty() {
             return Ok(Vec::new());
         }
@@ -380,7 +405,7 @@ impl PubMedClient {
         // NCBI recommends batches of up to 200 IDs per request
         const BATCH_SIZE: usize = 200;
 
-        let mut all_articles = Vec::with_capacity(pmids.len());
+        let mut all_items = Vec::with_capacity(pmids.len());
 
         for chunk in validated.chunks(BATCH_SIZE) {
             let id_list: String = chunk
@@ -389,34 +414,31 @@ impl PubMedClient {
                 .collect::<Vec<_>>()
                 .join(",");
 
-            debug!(batch_size = chunk.len(), "Making batch EFetch API request");
-            let response = self
-                .get_eutils(
-                    "efetch.fcgi",
-                    &[
-                        ("db", "pubmed"),
-                        ("id", id_list.as_str()),
-                        ("retmode", "xml"),
-                        ("rettype", "abstract"),
-                    ],
-                )
-                .await?;
-            let xml_text = response.text().await?;
+            let mut params: Vec<(&str, &str)> = vec![("db", "pubmed"), ("id", id_list.as_str())];
+            params.extend_from_slice(extra_params);
 
-            if xml_text.trim().is_empty() {
+            debug!(
+                batch_size = chunk.len(),
+                endpoint, "Making batch E-utilities API request"
+            );
+            let response = self.get_eutils(endpoint, &params).await?;
+            let body = response.text().await?;
+
+            if body.trim().is_empty() {
                 continue;
             }
 
-            let articles = parse_articles_from_xml(&xml_text)?;
+            let items = parse_fn(&body)?;
             info!(
                 requested = chunk.len(),
-                parsed = articles.len(),
+                parsed = items.len(),
+                endpoint,
                 "Batch fetch completed"
             );
-            all_articles.extend(articles);
+            all_items.extend(items);
         }
 
-        Ok(all_articles)
+        Ok(all_items)
     }
 
     /// Search and fetch multiple articles with metadata

--- a/pubmed-client/src/pubmed/client/summary.rs
+++ b/pubmed-client/src/pubmed/client/summary.rs
@@ -1,11 +1,10 @@
 //! ESummary API operations for fetching lightweight article metadata
 
-use crate::common::PubMedId;
 use crate::error::{ParseError, PubMedError, Result};
 use crate::pubmed::models::ArticleSummary;
 use crate::pubmed::query::SortOrder;
 use crate::pubmed::responses::{ESummaryDocSum, ESummaryResponse};
-use tracing::{debug, info, instrument, warn};
+use tracing::{instrument, warn};
 
 use super::PubMedClient;
 
@@ -41,61 +40,13 @@ impl PubMedClient {
     /// ```
     #[instrument(skip(self), fields(pmids_count = pmids.len()))]
     pub async fn fetch_summaries(&self, pmids: &[&str]) -> Result<Vec<ArticleSummary>> {
-        if pmids.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Validate all PMIDs upfront
-        let validated: Vec<u32> = pmids
-            .iter()
-            .map(|pmid| {
-                PubMedId::parse(pmid)
-                    .map(|p| p.as_u32())
-                    .map_err(PubMedError::from)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        const BATCH_SIZE: usize = 200;
-
-        let mut all_summaries = Vec::with_capacity(pmids.len());
-
-        for chunk in validated.chunks(BATCH_SIZE) {
-            let id_list: String = chunk
-                .iter()
-                .map(|id| id.to_string())
-                .collect::<Vec<_>>()
-                .join(",");
-
-            debug!(
-                batch_size = chunk.len(),
-                "Making batch ESummary API request"
-            );
-            let response = self
-                .get_eutils(
-                    "esummary.fcgi",
-                    &[
-                        ("db", "pubmed"),
-                        ("id", id_list.as_str()),
-                        ("retmode", "json"),
-                    ],
-                )
-                .await?;
-            let json_text = response.text().await?;
-
-            if json_text.trim().is_empty() {
-                continue;
-            }
-
-            let summaries = Self::parse_esummary_response(&json_text)?;
-            info!(
-                requested = chunk.len(),
-                parsed = summaries.len(),
-                "ESummary batch completed"
-            );
-            all_summaries.extend(summaries);
-        }
-
-        Ok(all_summaries)
+        self.batch_fetch_pmids(
+            pmids,
+            "esummary.fcgi",
+            &[("retmode", "json")],
+            Self::parse_esummary_response,
+        )
+        .await
     }
 
     /// Fetch a single article summary by PMID using the ESummary API


### PR DESCRIPTION
## Summary

Eliminates two genuine duplications in the `pubmed-client` core that the code-health sweep surfaced (P2-A and P2-C). Pure helper extraction — **no public API change**.

- **Batch fetch loop** — added a generic `batch_fetch_pmids<T, F>(pmids, endpoint, extra_params, parse_fn)` helper that owns PMID validation, 200-ID chunking, the per-batch E-utilities request, empty-body skip, and parse/extend. `fetch_articles` (`efetch.fcgi` + `parse_articles_from_xml`) and `fetch_summaries` (`esummary.fcgi` + `parse_esummary_response`) now forward to it — each body shrinks from ~55 lines to ~8.
- **ELink traversal** — added `collect_linked_pmids(response, link_name)` for the shared `linksets → linkset_dbs → links` walk + `u32` parse + sort/dedup, now used by `get_related_articles` and `get_citations`. `get_pmc_links` is left alone (collects strings filtered by `db_to` — genuinely different shape).
- Removed now-unused imports from `summary.rs`.

## Behavior note

Batch logging is unified to generic messages with an `endpoint` field, replacing the separate `EFetch`/`ESummary`-specific strings. Same information, just consolidated.

## Verification

- `cargo test -p pubmed-client --lib` → 256 passed
- `mocked_batch_fetch` (13), `parsing_elink` (3), `parsing_esummary` (3), `mocked_reexports` (3) → all passed
- `cargo clippy -p pubmed-client --all-targets` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)