### PR TITLE
ci(release): migrate crates.io to Trusted Publishing, fix npm/PyPI OIDC

### DIFF
--- a/.github/workflows/_publish-crate.yml
+++ b/.github/workflows/_publish-crate.yml
@@ -22,17 +22,27 @@ on:
         required: false
         type: boolean
         default: true
-    secrets:
-      CRATES_IO_TOKEN:
-        description: "Token for publishing to crates.io"
-        required: true
+      environment:
+        description: >-
+          GitHub Environment to run the publish in. Its OIDC `environment` claim
+          must match the crates.io Trusted Publisher config. Empty string = no
+          environment gate (used for dry-runs).
+        required: false
+        type: string
+        default: ""
 
 jobs:
   publish:
     name: Publish ${{ inputs.package }} to crates.io
     runs-on: ubuntu-latest
+    # An empty string disables the environment gate (dry-run path). Real
+    # publishes run in the `release` environment so the OIDC token carries the
+    # `environment` claim crates.io's Trusted Publisher requires.
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
+      # Trusted Publishing: mint a short-lived crates.io token via OIDC.
+      id-token: write
     timeout-minutes: 30
     steps:
       - name: Checkout code
@@ -146,23 +156,31 @@ jobs:
         if: ${{ inputs.dry-run }}
         working-directory: ${{ steps.pkg-path.outputs.path }}
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
           PKG_NAME: ${{ inputs.package }}
         run: |
           echo "Dry run - would publish: $PKG_NAME"
           # --no-verify: the verify build would resolve internal deps from
           # crates.io, which aren't published in a dry-run. See the Validate step.
-          cargo publish --dry-run --no-verify --token "$CARGO_REGISTRY_TOKEN"
+          # No auth needed: --dry-run never contacts the registry for upload.
+          cargo publish --dry-run --no-verify
+
+      # Trusted Publishing: exchange the job's OIDC token for a short-lived
+      # crates.io token. Requires a Trusted Publisher configured for this crate
+      # on crates.io (repo + workflow). No long-lived CRATES_IO_TOKEN secret.
+      - name: Authenticate to crates.io (Trusted Publishing)
+        id: auth
+        if: ${{ !inputs.dry-run && steps.published.outputs.exists != 'true' }}
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
       - name: Publish to crates.io
         if: ${{ !inputs.dry-run && steps.published.outputs.exists != 'true' }}
         working-directory: ${{ steps.pkg-path.outputs.path }}
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
           PKG_NAME: ${{ inputs.package }}
         run: |
           echo "Publishing package: $PKG_NAME"
-          cargo publish --token "$CARGO_REGISTRY_TOKEN"
+          cargo publish
 
       - name: Wait for crate to appear in the registry index
         if: ${{ !inputs.dry-run && steps.published.outputs.exists != 'true' }}

--- a/.github/workflows/_publish-napi.yml
+++ b/.github/workflows/_publish-napi.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: boolean
         default: false
+      environment:
+        description: >-
+          GitHub Environment for the publish job. Its OIDC `environment` claim
+          must match the npm Trusted Publisher config. Empty string = no
+          environment gate (used for dry-runs).
+        required: false
+        type: string
+        default: ""
 
 env:
   CARGO_TERM_COLOR: always
@@ -104,6 +112,10 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: [build]
+    # Empty string disables the gate (dry-run); real publishes run in `release`
+    # so the OIDC token carries the `environment` claim npm's Trusted Publisher
+    # requires.
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
       id-token: write # npm provenance (trusted publishing)

--- a/.github/workflows/_publish-python.yml
+++ b/.github/workflows/_publish-python.yml
@@ -1,18 +1,19 @@
-name: "Publish Python (PyPI)"
+name: "Build Python wheels"
 
-# Reusable workflow: build wheels for every platform and publish
-# `pubmed-client-py` to PyPI via trusted publishing. The package version comes
-# from the workspace Cargo.toml (kept in sync by scripts/sync-versions.sh).
-# Invoked by release.yml. Set dry-run to publish to TestPyPI instead of PyPI.
+# Reusable workflow: build wheels + sdist for every platform and upload them as
+# `wheels-*` artifacts, then run the test suite against the built wheel. The
+# package version comes from the workspace Cargo.toml (kept in sync by
+# scripts/sync-versions.sh).
+#
+# Publishing is intentionally NOT done here: PyPI Trusted Publishing matches the
+# OIDC `job_workflow_ref` claim, which for a reusable workflow points at this
+# file rather than the entry workflow — and PyPI has no way to configure a
+# reusable workflow as the trusted publisher (pypi/warehouse#11096). So the
+# `pypa/gh-action-pypi-publish` step lives directly in release.yml, where
+# `job_workflow_ref` == release.yml and the trusted publisher matches.
 
 on:
-  workflow_call:
-    inputs:
-      dry-run:
-        description: "Publish to TestPyPI instead of PyPI"
-        required: false
-        type: boolean
-        default: false
+  workflow_call: {}
 
 jobs:
   linux:
@@ -160,6 +161,11 @@ jobs:
       contents: read
     timeout-minutes: 15
     needs: [linux]
+    # uv (and PYO3_PYTHON) live in mise.python.toml, which mise only loads when
+    # MISE_ENV=python. Without this the mise step installs nothing and the later
+    # `uv venv` fails with "uv: command not found" (exit 127).
+    env:
+      MISE_ENV: python
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -192,54 +198,3 @@ jobs:
         run: |
           cd pubmed-client-py
           uv run mypy tests/ --strict
-
-  publish:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    needs: [linux, windows, macos, sdist, test]
-    if: ${{ !inputs.dry-run }}
-    environment:
-      name: pypi
-      url: https://pypi.org/p/pubmed-client
-    permissions:
-      id-token: write # IMPORTANT: mandatory for trusted publishing
-    timeout-minutes: 10
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
-        with:
-          skip-existing: true
-          verbose: true
-
-  publish-test:
-    name: Publish to TestPyPI
-    runs-on: ubuntu-latest
-    needs: [linux, windows, macos, sdist, test]
-    if: ${{ inputs.dry-run }}
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/pubmed-client
-    permissions:
-      id-token: write
-    timeout-minutes: 10
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-          verbose: true

--- a/.github/workflows/_publish-wasm.yml
+++ b/.github/workflows/_publish-wasm.yml
@@ -13,6 +13,14 @@ on:
         required: false
         type: boolean
         default: false
+      environment:
+        description: >-
+          GitHub Environment for the publish job. Its OIDC `environment` claim
+          must match the npm Trusted Publisher config. Empty string = no
+          environment gate (used for dry-runs).
+        required: false
+        type: string
+        default: ""
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,6 +30,10 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    # Empty string disables the gate (dry-run); real publishes run in `release`
+    # so the OIDC token carries the `environment` claim npm's Trusted Publisher
+    # requires.
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
       id-token: write # npm provenance (trusted publishing)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,70 +105,70 @@ jobs:
     needs: [guard, test]
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/_publish-crate.yml
     with:
       package: pubmed-parser
       package-path: pubmed-parser
       check-version: ${{ github.event_name == 'push' }}
       dry-run: ${{ needs.guard.outputs.dry-run == 'true' }}
-    secrets:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      environment: ${{ needs.guard.outputs.dry-run == 'true' && '' || 'release' }}
 
   publish-formatter:
     name: crates.io · pubmed-formatter
     needs: [guard, publish-parser]
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/_publish-crate.yml
     with:
       package: pubmed-formatter
       package-path: pubmed-formatter
       check-version: ${{ github.event_name == 'push' }}
       dry-run: ${{ needs.guard.outputs.dry-run == 'true' }}
-    secrets:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      environment: ${{ needs.guard.outputs.dry-run == 'true' && '' || 'release' }}
 
   publish-client:
     name: crates.io · pubmed-client
     needs: [guard, publish-formatter]
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/_publish-crate.yml
     with:
       package: pubmed-client
       package-path: pubmed-client
       check-version: ${{ github.event_name == 'push' }}
       dry-run: ${{ needs.guard.outputs.dry-run == 'true' }}
-    secrets:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      environment: ${{ needs.guard.outputs.dry-run == 'true' && '' || 'release' }}
 
   publish-cli:
     name: crates.io · pubmed-cli
     needs: [guard, publish-client]
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/_publish-crate.yml
     with:
       package: pubmed-cli
       package-path: pubmed-cli
       check-version: ${{ github.event_name == 'push' }}
       dry-run: ${{ needs.guard.outputs.dry-run == 'true' }}
-    secrets:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      environment: ${{ needs.guard.outputs.dry-run == 'true' && '' || 'release' }}
 
   publish-mcp:
     name: crates.io · pubmed-mcp
     needs: [guard, publish-client]
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/_publish-crate.yml
     with:
       package: pubmed-mcp
       package-path: pubmed-mcp
       check-version: ${{ github.event_name == 'push' }}
       dry-run: ${{ needs.guard.outputs.dry-run == 'true' }}
-    secrets:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      environment: ${{ needs.guard.outputs.dry-run == 'true' && '' || 'release' }}
 
   # ── npm ──────────────────────────────────────────────────────────────────────
   publish-napi:
@@ -180,6 +180,7 @@ jobs:
     uses: ./.github/workflows/_publish-napi.yml
     with:
       dry-run: ${{ needs.guard.outputs.dry-run == 'true' }}
+      environment: ${{ needs.guard.outputs.dry-run == 'true' && '' || 'release' }}
 
   publish-wasm:
     name: npm · pubmed-client-wasm
@@ -190,17 +191,74 @@ jobs:
     uses: ./.github/workflows/_publish-wasm.yml
     with:
       dry-run: ${{ needs.guard.outputs.dry-run == 'true' }}
+      environment: ${{ needs.guard.outputs.dry-run == 'true' && '' || 'release' }}
 
   # ── PyPI ─────────────────────────────────────────────────────────────────────
-  publish-python:
-    name: PyPI · pubmed-client-py
+  # Build wheels in the reusable workflow, but publish from a job defined HERE.
+  # PyPI Trusted Publishing matches the OIDC `job_workflow_ref`, which for a
+  # reusable workflow would be `_publish-python.yml` (unconfigurable on PyPI —
+  # pypi/warehouse#11096). Keeping the publish step in release.yml makes the
+  # claim resolve to `release.yml`, so the PyPI trusted publisher matches.
+  build-python:
+    name: PyPI · build wheels
     needs: [guard, test]
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/_publish-python.yml
-    with:
-      dry-run: ${{ needs.guard.outputs.dry-run == 'true' }}
+
+  publish-python:
+    name: PyPI · pubmed-client-py
+    needs: [guard, build-python]
+    if: ${{ needs.guard.outputs.dry-run != 'true' }}
+    runs-on: ubuntu-latest
+    # Real publishes only run on a v* tag push, so the `release` environment's
+    # tag policy is always satisfied here. PyPI's trusted publisher is pinned to
+    # environment `release` to match.
+    environment:
+      name: release
+      url: https://pypi.org/p/pubmed-client-py
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+    timeout-minutes: 10
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        with:
+          skip-existing: true
+          verbose: true
+
+  publish-python-test:
+    name: PyPI · pubmed-client-py (TestPyPI dry-run)
+    needs: [guard, build-python]
+    if: ${{ needs.guard.outputs.dry-run == 'true' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pubmed-client
+    permissions:
+      id-token: write
+    timeout-minutes: 10
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true
 
   # ── GitHub Release (real releases only) ──────────────────────────────────────
   create-release:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,12 +62,54 @@ pipeline without publishing: crates use `cargo publish --dry-run`, npm uses
 > meaningful for packaging/version checks; the real release still verifies, publishing in
 > dependency order and waiting for each crate to land in the registry index before the next.
 
+## Authentication (Trusted Publishing)
+
+crates.io publishing uses **Trusted Publishing** (OIDC) — there is **no** long-lived
+`CRATES_IO_TOKEN` secret. `_publish-crate.yml` mints a short-lived token at publish time
+via [`rust-lang/crates-io-auth-action`](https://github.com/rust-lang/crates-io-auth-action)
+(the job grants `id-token: write`). PyPI and npm publish jobs likewise use OIDC.
+
+All real publish jobs (crates.io, npm, PyPI) run in the **`release` GitHub Environment**, which
+is restricted to `v*` tags (deployment tag policy). The OIDC token therefore carries an
+`environment: release` claim, and every Trusted Publisher (crates.io per-crate, npm per-package,
+PyPI) is pinned to that environment — so only a `v*`-tag-triggered run of `release.yml` can
+publish. Dry-runs (`workflow_dispatch`) pass an empty environment and skip the gate (crates also
+skip the auth step); the TestPyPI dry-run job uses a separate `testpypi` environment (no tag
+policy) so dispatch runs from a branch are allowed.
+
+> **One-time setup per crate** (already done for all five as of 0.2.0): crates.io has **no
+> "pending publisher"** — a Trusted Publisher can only be configured on a crate that already
+> exists. Each of `pubmed-parser`, `pubmed-formatter`, `pubmed-client`, `pubmed-cli`,
+> `pubmed-mcp` has a Trusted Publisher (repo `illumination-k/pubmed-client`, workflow
+> `release.yml`, environment `release`). All five were bootstrap-published at 0.1.1 to make
+> this possible. A brand-new crate added later needs a manual first publish with a token, then
+> the same Trusted Publisher + environment config. Configure via the crate's
+> `https://crates.io/crates/<crate>/settings` page, or `POST /api/v1/trusted_publishing/github_configs`.
+
+### Trusted Publishing matches different OIDC claims per registry
+
+A registry validates the GitHub OIDC token against either the **entry** workflow
+(`workflow_ref`, always `release.yml`) or the **defining** workflow (`job_workflow_ref`, the
+reusable file). This dictates whether the publish step may live in a reusable workflow:
+
+| Registry  | Matches claim      | Reusable workflow?                    | Where the publish step lives                                            |
+| --------- | ------------------ | ------------------------------------- | ----------------------------------------------------------------------- |
+| crates.io | `workflow_ref`     | ✅ safe                               | `_publish-crate.yml` (reusable) — claim still resolves to `release.yml` |
+| npm       | calling/top-level  | ✅ if configured with `release.yml`   | `_publish-napi.yml` / `_publish-wasm.yml` (reusable)                    |
+| PyPI      | `job_workflow_ref` | ❌ unsupported (pypi/warehouse#11096) | **directly in `release.yml`**                                           |
+
+So configure every Trusted Publisher (crates.io, npm, PyPI) with workflow filename **`release.yml`**
+and environment **`release`**. PyPI cannot match a reusable workflow, so the
+`pypa/gh-action-pypi-publish` step is inlined into `release.yml`; `_publish-python.yml` only builds
+wheels. (The TestPyPI dry-run publisher uses environment `testpypi` instead.)
+
 ## Workflow layout
 
-- `release.yml` — the single entry point (tag `v*` or manual dry-run).
-- `_publish-crate.yml` — reusable crates.io publisher (one call per crate).
+- `release.yml` — the single entry point (tag `v*` or manual dry-run); also contains the PyPI
+  publish/TestPyPI jobs inline (see note above).
+- `_publish-crate.yml` — reusable crates.io publisher (one call per crate); Trusted Publishing.
 - `_publish-napi.yml` — reusable NAPI build matrix + npm publish.
 - `_publish-wasm.yml` — reusable wasm-pack build + npm publish.
-- `_publish-python.yml` — reusable wheel build matrix + PyPI/TestPyPI publish.
+- `_publish-python.yml` — reusable wheel **build** matrix + test (no publish — see note above).
 
 CI workflows (`ci-napi.yml`, `ci-wasm.yml`, etc.) are build/test only and no longer publish.


### PR DESCRIPTION
## Summary

Fixes the v0.2.0 release pipeline, which failed on authentication. Moves crates.io off the long-lived `CRATES_IO_TOKEN` secret to **Trusted Publishing**, and repairs the npm/PyPI publish jobs so their OIDC claims actually match a Trusted Publisher.

### Why each registry differs
A registry validates the GitHub OIDC token against either the **entry** workflow (`workflow_ref`, always `release.yml`) or the **defining** workflow (`job_workflow_ref`, the reusable file). This dictates whether the publish step may live in a reusable workflow:

| Registry  | Matches claim | Reusable OK? | Publish step location |
|-----------|---------------|--------------|-----------------------|
| crates.io | `workflow_ref` | ✅ | `_publish-crate.yml` (reusable) |
| npm | calling/top-level | ✅ (configure `release.yml`) | `_publish-napi.yml` / `_publish-wasm.yml` |
| PyPI | `job_workflow_ref` | ❌ ([warehouse#11096](https://github.com/pypi/warehouse/issues/11096)) | **inlined into `release.yml`** |

## Changes
- **crates.io → Trusted Publishing**: `_publish-crate.yml` uses `rust-lang/crates-io-auth-action@v1.0.5` + `id-token: write` instead of `CRATES_IO_TOKEN`.
- **PyPI**: inline the `pypa/gh-action-pypi-publish` step into `release.yml` (`publish-python` / `publish-python-test`); `_publish-python.yml` is now build-only (wheels + test, uploads `wheels-*` artifacts).
- **npm**: `_publish-napi.yml` / `_publish-wasm.yml` gain an `environment` input.
- **Unified `release` environment**: all real publish jobs run in the `release` GitHub Environment (restricted to `v*` tags). Dry-runs pass an empty environment and skip the gate; TestPyPI dry-run uses a separate `testpypi` environment.
- **Fix Python test job**: `uv: command not found` → set `MISE_ENV=python` so mise loads `uv` from `mise.python.toml`.
- Document the per-registry OIDC behavior in `RELEASING.md`.

## Out-of-band setup required before tagging v0.2.0
- **crates.io**: Trusted Publishers already configured for all 5 crates (workflow `release.yml`, env `release`). All 5 bootstrap-published at 0.1.1.
- **npm**: configure Trusted Publishing (workflow `release.yml`, env `release`) for `pubmed-client` + 7 platform packages; **`pubmed-client-wasm` is new and must be first-published once with a token** (TP can't bootstrap a new package).
- **PyPI**: configure the trusted publisher with workflow `release.yml`, env `release` (TestPyPI: env `testpypi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)