### PR TITLE
feat(wasm): expand WasmSearchQuery builder and add PMC markdown/OA methods

### DIFF
--- a/pubmed-client-wasm/README.md
+++ b/pubmed-client-wasm/README.md
@@ -46,9 +46,15 @@ searchArticles().catch(console.error);
 
 ### PMC Full-Text Access
 
-- Check PMC availability for articles
+- Check PMC availability and Open Access (OA) subset status
 - Retrieve structured full-text content
-- Convert articles to Markdown format
+- Convert articles to Markdown format (with configurable options)
+
+### Query Builder
+
+- Fluent `WasmSearchQuery` builder with field filters (title, author, MeSH, journal, ORCID, …)
+- Date-range, article-type, language, and study-population filters
+- Boolean composition: AND / OR / NOT / exclude / grouping
 
 ### Advanced Features
 
@@ -165,6 +171,52 @@ console.log(markdown);
 
 **Returns:** string
 
+##### fetch_pmc_as_markdown(pmcid, options?)
+
+Fetch a PMC article and convert it to Markdown in a single call.
+
+```javascript
+const markdown = await client.fetch_pmc_as_markdown("PMC7239045", {
+    include_metadata: true,
+    include_toc: true,
+    use_yaml_frontmatter: true,
+    include_orcid_links: false,
+    include_figure_captions: true,
+});
+console.log(markdown);
+```
+
+**Parameters:**
+
+- `pmcid` (string): PMC ID
+- `options` (object, optional): Markdown conversion options. All fields are
+  optional booleans; unset fields fall back to converter defaults:
+  `include_metadata`, `include_toc`, `use_yaml_frontmatter`,
+  `include_orcid_links`, `include_figure_captions`.
+
+**Returns:** Promise<string>
+
+##### is_oa_subset(pmcid)
+
+Check whether a PMC article is in the Open Access (OA) subset (i.e. has
+programmatic full-text access).
+
+```javascript
+const info = await client.is_oa_subset("PMC7239045");
+if (info.is_oa_subset) {
+    console.log(`License: ${info.license}`);
+    console.log(`Download: ${info.download_link}`);
+} else {
+    console.log(`Not in OA subset: ${info.error_code}`);
+}
+```
+
+**Parameters:**
+
+- `pmcid` (string): PMC ID
+
+**Returns:** Promise<OaSubsetInfo>
+
 ##### get_related_articles(pmids)
 
 Find articles related to given PMIDs.
@@ -179,6 +231,66 @@ console.log(`Found ${related.related_pmids.length} related articles`);
 - `pmids` (number[]): Array of PubMed IDs
 
 **Returns:** Promise<RelatedArticles>
+
+### WasmSearchQuery
+
+A fluent builder for constructing complex PubMed queries with field filters,
+date ranges, article types, and boolean composition. Build a query string with
+`build()`, or run it directly with `search_and_fetch(client, limit)`.
+
+```javascript
+const { WasmSearchQuery, WasmPubMedClient } = require('pubmed-client-wasm');
+
+const client = new WasmPubMedClient();
+
+const query = new WasmSearchQuery()
+    .title_abstract("CRISPR")
+    .mesh_term("Neoplasms")
+    .author("Zhang Y")
+    .article_types_str(["Review", "Meta-Analysis"])
+    .published_between(2019, 2023)
+    .humans_only();
+
+console.log(query.build());
+// (CRISPR[tiab]) AND ... AND (2019:2023[pdat]) ...
+
+const articles = await query.search_and_fetch(client, 20);
+```
+
+#### Field filters
+
+- `query(text)`, `terms(string[])`, `custom_filter(text)`
+- `title(text)`, `abstract_contains(text)`, `title_abstract(text)`, `has_abstract()`
+- `author(name)`, `first_author(name)`, `last_author(name)`, `affiliation(institution)`, `orcid(id)`
+- `journal(name)`, `journal_abbreviation(abbrev)`, `grant_number(gr)`, `isbn(isbn)`, `issn(issn)`
+- `mesh_term(term)`, `mesh_terms(string[])`, `mesh_major_topic(term)`, `mesh_subheading(sh)`
+
+#### Filters & study population
+
+- `free_full_text_only()`, `full_text_only()`, `pmc_only()`
+- `humans_only()`, `animal_studies_only()`, `age_group(group)`, `organism_mesh(organism)`
+- `article_type_str(type)`, `article_types_str(string[])`, `language_str(lang)`, `sort_str(order)`
+
+#### Dates (years must be 1800–3000)
+
+- `published_after(year)`, `published_before(year)`, `published_in_year(year)`
+- `published_between(startYear, endYear?)`, `date_range(startYear, endYear?)`
+
+#### Boolean composition
+
+These return a **new** query and do not consume their operands:
+
+- `and(other)`, `or(other)`, `negate()`, `exclude(other)`, `group()`
+
+```javascript
+const a = new WasmSearchQuery().query("diabetes");
+const b = new WasmSearchQuery().query("hypertension");
+a.or(b).build(); // "(diabetes) OR (hypertension)"
+```
+
+#### Misc
+
+- `limit(n)` / `get_limit()`, `build()`, `search_and_fetch(client, limit)`
 
 ## Data Types
 
@@ -235,6 +347,23 @@ interface Section {
     section_type: string;
     title?: string;
     content: string;
+}
+```
+
+### OaSubsetInfo
+
+```typescript
+interface OaSubsetInfo {
+    pmcid: string;
+    is_oa_subset: boolean;
+    citation?: string;
+    license?: string;
+    retracted: boolean;
+    download_link?: string;
+    download_format?: string;
+    updated?: string;
+    error_code?: string;
+    error_message?: string;
 }
 ```
 

--- a/pubmed-client-wasm/src/lib.rs
+++ b/pubmed-client-wasm/src/lib.rs
@@ -516,6 +516,115 @@ impl WasmPubMedClient {
         let converter = pubmed_client::pmc::PmcMarkdownConverter::new();
         Ok(converter.convert(&full_text))
     }
+
+    /// Fetch a PMC article and convert it to markdown in a single call
+    ///
+    /// `options` is an optional object with boolean fields: `include_metadata`,
+    /// `include_toc`, `use_yaml_frontmatter`, `include_orcid_links`,
+    /// `include_figure_captions`. Unset fields fall back to converter defaults.
+    pub fn fetch_pmc_as_markdown(&self, pmcid: String, options: JsValue) -> js_sys::Promise {
+        let client = self.client.clone();
+        // Parse options synchronously so a malformed value rejects eagerly.
+        let parsed: Result<Option<JsMarkdownOptions>, _> =
+            if options.is_undefined() || options.is_null() {
+                Ok(None)
+            } else {
+                serde_wasm_bindgen::from_value(options).map(Some)
+            };
+        future_to_promise(async move {
+            let options = parsed
+                .map_err(|e| JsValue::from_str(&format!("Invalid markdown options: {e}")))?
+                .unwrap_or_default();
+            match client.pmc.fetch_full_text(&pmcid).await {
+                Ok(full_text) => {
+                    let mut converter = pubmed_client::pmc::PmcMarkdownConverter::new();
+                    if let Some(v) = options.include_metadata {
+                        converter = converter.with_include_metadata(v);
+                    }
+                    if let Some(v) = options.include_toc {
+                        converter = converter.with_include_toc(v);
+                    }
+                    if let Some(v) = options.use_yaml_frontmatter {
+                        converter = converter.with_yaml_frontmatter(v);
+                    }
+                    if let Some(v) = options.include_orcid_links {
+                        converter = converter.with_include_orcid_links(v);
+                    }
+                    if let Some(v) = options.include_figure_captions {
+                        converter = converter.with_include_figure_captions(v);
+                    }
+                    Ok(JsValue::from_str(&converter.convert(&full_text)))
+                }
+                Err(e) => Err(to_js_err(e)),
+            }
+        })
+    }
+
+    /// Check whether a PMC article is in the Open Access (OA) subset
+    ///
+    /// Resolves to a `JsOaSubsetInfo` object describing programmatic full-text
+    /// availability, license, download link, and (when not available) error details.
+    pub fn is_oa_subset(&self, pmcid: String) -> js_sys::Promise {
+        let client = self.client.clone();
+        future_to_promise(async move {
+            match client.pmc.is_oa_subset(&pmcid).await {
+                Ok(info) => {
+                    let js_info = JsOaSubsetInfo::from(info);
+                    Ok(serde_wasm_bindgen::to_value(&js_info)?)
+                }
+                Err(e) => Err(to_js_err(e)),
+            }
+        })
+    }
+}
+
+/// JavaScript-friendly markdown conversion options
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct JsMarkdownOptions {
+    #[serde(default)]
+    pub include_metadata: Option<bool>,
+    #[serde(default)]
+    pub include_toc: Option<bool>,
+    #[serde(default)]
+    pub use_yaml_frontmatter: Option<bool>,
+    #[serde(default)]
+    pub include_orcid_links: Option<bool>,
+    #[serde(default)]
+    pub include_figure_captions: Option<bool>,
+}
+
+/// JavaScript-friendly OA (Open Access) subset availability information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "tsify", derive(tsify::Tsify))]
+#[cfg_attr(feature = "tsify", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct JsOaSubsetInfo {
+    pub pmcid: String,
+    pub is_oa_subset: bool,
+    pub citation: Option<String>,
+    pub license: Option<String>,
+    pub retracted: bool,
+    pub download_link: Option<String>,
+    pub download_format: Option<String>,
+    pub updated: Option<String>,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+}
+
+impl From<pubmed_client::OaSubsetInfo> for JsOaSubsetInfo {
+    fn from(info: pubmed_client::OaSubsetInfo) -> Self {
+        Self {
+            pmcid: info.pmcid,
+            is_oa_subset: info.is_oa_subset,
+            citation: info.citation,
+            license: info.license,
+            retracted: info.retracted,
+            download_link: info.download_link,
+            download_format: info.download_format,
+            updated: info.updated,
+            error_code: info.error_code,
+            error_message: info.error_message,
+        }
+    }
 }
 
 /// JavaScript-friendly EPost result
@@ -1158,6 +1267,20 @@ impl From<pubmed_client::SpellCheckResult> for JsSpellCheckResult {
 // WasmSearchQuery builder
 // ================================================================================================
 
+/// Map legacy snake_case article-type aliases to the canonical names accepted by
+/// `ArticleType::from_str_insensitive`. Unknown values pass through unchanged.
+fn normalize_article_type(article_type: &str) -> &str {
+    match article_type {
+        "clinical_trial" => "Clinical Trial",
+        "meta_analysis" => "Meta-Analysis",
+        "randomized_controlled_trial" => "Randomized Controlled Trial",
+        "systematic_review" => "Systematic Review",
+        "case_report" => "Case Reports",
+        "observational_study" => "Observational Study",
+        other => other,
+    }
+}
+
 /// Search query builder for constructing complex PubMed queries
 ///
 /// Provides a fluent API for building PubMed search queries with filters,
@@ -1273,16 +1396,7 @@ impl WasmSearchQuery {
     /// `"Randomized Controlled Trial"` / `"RCT"`, `"Observational Study"`.
     /// Also accepts the legacy snake_case aliases used in previous versions.
     pub fn article_type_str(mut self, article_type: &str) -> Result<Self, JsValue> {
-        // Support legacy snake_case aliases for backwards compatibility
-        let normalized = match article_type {
-            "clinical_trial" => "Clinical Trial",
-            "meta_analysis" => "Meta-Analysis",
-            "randomized_controlled_trial" => "Randomized Controlled Trial",
-            "systematic_review" => "Systematic Review",
-            "case_report" => "Case Reports",
-            "observational_study" => "Observational Study",
-            other => other,
-        };
+        let normalized = normalize_article_type(article_type);
         let at = pubmed_client::ArticleType::from_str_insensitive(normalized)
             .map_err(|e| JsValue::from_str(&e))?;
         self.inner = self.inner.article_type(at);
@@ -1313,6 +1427,202 @@ impl WasmSearchQuery {
             .map_err(|e| JsValue::from_str(&e))?;
         self.inner = self.inner.sort(order);
         Ok(self)
+    }
+
+    /// Add multiple search terms (joined with the default AND logic)
+    pub fn terms(mut self, terms: Vec<String>) -> Self {
+        self.inner = self.inner.terms(&terms);
+        self
+    }
+
+    /// Set the maximum number of results to retrieve
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.inner = self.inner.limit(limit);
+        self
+    }
+
+    /// Get the currently configured result limit
+    pub fn get_limit(&self) -> usize {
+        self.inner.get_limit()
+    }
+
+    /// Search in article abstracts only
+    pub fn abstract_contains(mut self, text: &str) -> Self {
+        self.inner = self.inner.abstract_contains(text);
+        self
+    }
+
+    /// Filter to only articles that have an abstract
+    pub fn has_abstract(mut self) -> Self {
+        self.inner = self.inner.has_abstract();
+        self
+    }
+
+    /// Search by journal abbreviation (e.g. "N Engl J Med")
+    pub fn journal_abbreviation(mut self, abbreviation: &str) -> Self {
+        self.inner = self.inner.journal_abbreviation(abbreviation);
+        self
+    }
+
+    /// Search by grant number
+    pub fn grant_number(mut self, grant_number: &str) -> Self {
+        self.inner = self.inner.grant_number(grant_number);
+        self
+    }
+
+    /// Search by ISBN
+    pub fn isbn(mut self, isbn: &str) -> Self {
+        self.inner = self.inner.isbn(isbn);
+        self
+    }
+
+    /// Search by ISSN
+    pub fn issn(mut self, issn: &str) -> Self {
+        self.inner = self.inner.issn(issn);
+        self
+    }
+
+    /// Search by last author name
+    pub fn last_author(mut self, author: &str) -> Self {
+        self.inner = self.inner.last_author(author);
+        self
+    }
+
+    /// Search by author affiliation / institution
+    pub fn affiliation(mut self, institution: &str) -> Self {
+        self.inner = self.inner.affiliation(institution);
+        self
+    }
+
+    /// Search by author ORCID identifier
+    pub fn orcid(mut self, orcid_id: &str) -> Self {
+        self.inner = self.inner.orcid(orcid_id);
+        self
+    }
+
+    /// Search by multiple MeSH terms (OR logic)
+    pub fn mesh_terms(mut self, terms: Vec<String>) -> Self {
+        self.inner = self.inner.mesh_terms(&terms);
+        self
+    }
+
+    /// Search by MeSH subheading
+    pub fn mesh_subheading(mut self, subheading: &str) -> Self {
+        self.inner = self.inner.mesh_subheading(subheading);
+        self
+    }
+
+    /// Filter to animal-only studies
+    pub fn animal_studies_only(mut self) -> Self {
+        self.inner = self.inner.animal_studies_only();
+        self
+    }
+
+    /// Filter by age group (e.g. "Adult", "Child")
+    pub fn age_group(mut self, age_group: &str) -> Self {
+        self.inner = self.inner.age_group(age_group);
+        self
+    }
+
+    /// Filter by organism using its MeSH term
+    pub fn organism_mesh(mut self, organism: &str) -> Self {
+        self.inner = self.inner.organism_mesh(organism);
+        self
+    }
+
+    /// Add a raw custom filter clause appended verbatim to the query
+    pub fn custom_filter(mut self, filter: &str) -> Self {
+        self.inner = self.inner.custom_filter(filter);
+        self
+    }
+
+    /// Filter by multiple article types (OR logic, case-insensitive).
+    ///
+    /// Accepts the same values as `article_type_str`, including the legacy
+    /// snake_case aliases. An empty array is a no-op.
+    pub fn article_types_str(mut self, article_types: Vec<String>) -> Result<Self, JsValue> {
+        if article_types.is_empty() {
+            return Ok(self);
+        }
+        let mut parsed = Vec::with_capacity(article_types.len());
+        for at in &article_types {
+            let normalized = normalize_article_type(at);
+            parsed.push(
+                pubmed_client::ArticleType::from_str_insensitive(normalized)
+                    .map_err(|e| JsValue::from_str(&e))?,
+            );
+        }
+        self.inner = self.inner.article_types(&parsed);
+        Ok(self)
+    }
+
+    /// Filter to a single publication year (must be 1800–3000)
+    pub fn published_in_year(mut self, year: u32) -> Result<Self, JsValue> {
+        pubmed_client::validate_year(year).map_err(|e| JsValue::from_str(&e))?;
+        self.inner = self.inner.published_in_year(year);
+        Ok(self)
+    }
+
+    /// Filter to a publication-year range (years must be 1800–3000)
+    pub fn published_between(
+        mut self,
+        start_year: u32,
+        end_year: Option<u32>,
+    ) -> Result<Self, JsValue> {
+        pubmed_client::validate_year(start_year).map_err(|e| JsValue::from_str(&e))?;
+        if let Some(end) = end_year {
+            pubmed_client::validate_year(end).map_err(|e| JsValue::from_str(&e))?;
+            if start_year > end {
+                return Err(JsValue::from_str(&format!(
+                    "Start year ({}) must be <= end year ({})",
+                    start_year, end
+                )));
+            }
+        }
+        self.inner = self.inner.published_between(start_year, end_year);
+        Ok(self)
+    }
+
+    /// Filter to articles published before a given year (must be 1800–3000)
+    pub fn published_before(mut self, year: u32) -> Result<Self, JsValue> {
+        pubmed_client::validate_year(year).map_err(|e| JsValue::from_str(&e))?;
+        self.inner = self.inner.published_before(year);
+        Ok(self)
+    }
+
+    /// Combine this query with another using AND logic, returning a new query
+    pub fn and(&self, other: &WasmSearchQuery) -> WasmSearchQuery {
+        WasmSearchQuery {
+            inner: self.inner.clone().and(other.inner.clone()),
+        }
+    }
+
+    /// Combine this query with another using OR logic, returning a new query
+    pub fn or(&self, other: &WasmSearchQuery) -> WasmSearchQuery {
+        WasmSearchQuery {
+            inner: self.inner.clone().or(other.inner.clone()),
+        }
+    }
+
+    /// Negate this query using NOT logic, returning a new query
+    pub fn negate(&self) -> WasmSearchQuery {
+        WasmSearchQuery {
+            inner: self.inner.clone().negate(),
+        }
+    }
+
+    /// Exclude articles matching another query, returning a new query
+    pub fn exclude(&self, excluded: &WasmSearchQuery) -> WasmSearchQuery {
+        WasmSearchQuery {
+            inner: self.inner.clone().exclude(excluded.inner.clone()),
+        }
+    }
+
+    /// Wrap this query in parentheses for grouping, returning a new query
+    pub fn group(&self) -> WasmSearchQuery {
+        WasmSearchQuery {
+            inner: self.inner.clone().group(),
+        }
     }
 
     /// Build the query string

--- a/pubmed-client-wasm/tests/query.test.ts
+++ b/pubmed-client-wasm/tests/query.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import { WasmSearchQuery } from '../pkg/pubmed_client_wasm.js'
+
+// These tests exercise the WasmSearchQuery builder offline. `build()` is pure
+// string construction with no network access, so the expected output mirrors the
+// core `SearchQuery` builder field tags.
+
+describe('WasmSearchQuery builder', () => {
+  describe('search field filters', () => {
+    it('builds title and title/abstract filters', () => {
+      expect(new WasmSearchQuery().title('machine learning').build()).toBe('machine learning[ti]')
+      expect(new WasmSearchQuery().title_abstract('CRISPR').build()).toBe('CRISPR[tiab]')
+      expect(new WasmSearchQuery().abstract_contains('genome').build()).toBe('genome[tiab]')
+    })
+
+    it('builds author, affiliation and ORCID filters', () => {
+      expect(new WasmSearchQuery().author('Williams K').build()).toBe('Williams K[au]')
+      expect(new WasmSearchQuery().first_author('Smith J').build()).toBe('Smith J[1au]')
+      expect(new WasmSearchQuery().last_author('Johnson M').build()).toBe('Johnson M[lastau]')
+      expect(new WasmSearchQuery().affiliation('Harvard Medical School').build()).toBe(
+        'Harvard Medical School[ad]'
+      )
+      expect(new WasmSearchQuery().orcid('0000-0001-2345-6789').build()).toBe(
+        '0000-0001-2345-6789[auid]'
+      )
+    })
+
+    it('builds MeSH filters', () => {
+      expect(new WasmSearchQuery().mesh_term('Neoplasms').build()).toBe('Neoplasms[mh]')
+      expect(new WasmSearchQuery().mesh_major_topic('Diabetes Mellitus, Type 2').build()).toBe(
+        'Diabetes Mellitus, Type 2[majr]'
+      )
+      expect(new WasmSearchQuery().mesh_terms(['Neoplasms', 'Antineoplastic Agents']).build()).toBe(
+        'Neoplasms[mh] AND Antineoplastic Agents[mh]'
+      )
+      expect(
+        new WasmSearchQuery().mesh_term('Diabetes Mellitus').mesh_subheading('drug therapy').build()
+      ).toBe('Diabetes Mellitus[mh] AND drug therapy[sh]')
+    })
+
+    it('builds identifier and metadata filters', () => {
+      expect(new WasmSearchQuery().isbn('978-0123456789').build()).toBe('978-0123456789[ISBN]')
+      expect(new WasmSearchQuery().issn('1234-5678').build()).toBe('1234-5678[ISSN]')
+      expect(new WasmSearchQuery().grant_number('CA123456').build()).toBe('CA123456[gr]')
+      expect(new WasmSearchQuery().has_abstract().build()).toBe('hasabstract')
+    })
+
+    it('builds study population filters', () => {
+      expect(new WasmSearchQuery().humans_only().build()).toBe('humans[mh]')
+      expect(new WasmSearchQuery().animal_studies_only().build()).toBe('animals[mh]')
+      expect(new WasmSearchQuery().age_group('Child').build()).toBe('Child[mh]')
+      expect(new WasmSearchQuery().organism_mesh('Mus musculus').build()).toBe('Mus musculus[mh]')
+    })
+
+    it('builds custom and multi-term filters', () => {
+      expect(new WasmSearchQuery().custom_filter('custom[field]').build()).toBe('custom[field]')
+      expect(new WasmSearchQuery().terms(['test', 'more']).build()).toBe('test more')
+    })
+  })
+
+  describe('article types', () => {
+    it('accepts a single type with legacy aliases', () => {
+      const q = new WasmSearchQuery().article_type_str('clinical_trial')
+      expect(q.build()).toContain('Clinical Trial[pt]')
+    })
+
+    it('accepts multiple types (OR logic)', () => {
+      const q = new WasmSearchQuery().article_types_str(['Review', 'Meta-Analysis'])
+      expect(q.build()).toBe('(Review[pt] OR Meta-Analysis[pt])')
+    })
+
+    it('treats an empty type list as a no-op', () => {
+      expect(new WasmSearchQuery().query('cancer').article_types_str([]).build()).toBe('cancer')
+    })
+
+    it('throws on an unknown article type', () => {
+      expect(() => new WasmSearchQuery().article_type_str('not-a-type')).toThrow()
+    })
+  })
+
+  describe('date filters', () => {
+    it('builds year and range filters', () => {
+      expect(new WasmSearchQuery().published_in_year(2020).build()).toContain('2020')
+      expect(new WasmSearchQuery().published_after(2018).build()).toContain('2018')
+      expect(new WasmSearchQuery().published_before(2022).build()).toContain('2022')
+      expect(new WasmSearchQuery().published_between(2019, 2021).build()).toContain('2019')
+    })
+
+    it('rejects out-of-range years', () => {
+      expect(() => new WasmSearchQuery().published_in_year(100)).toThrow()
+    })
+
+    it('rejects an inverted range', () => {
+      expect(() => new WasmSearchQuery().published_between(2022, 2020)).toThrow()
+    })
+
+    it('configures the result limit', () => {
+      const q = new WasmSearchQuery().limit(25)
+      expect(q.get_limit()).toBe(25)
+    })
+  })
+
+  describe('boolean composition', () => {
+    it('combines queries with AND / OR', () => {
+      const a = new WasmSearchQuery().query('diabetes')
+      const b = new WasmSearchQuery().query('hypertension')
+      expect(a.or(b).build()).toBe('(diabetes) OR (hypertension)')
+
+      const c = new WasmSearchQuery().query('cancer')
+      const d = new WasmSearchQuery().query('treatment')
+      expect(c.and(d).build()).toBe('(cancer) AND (treatment)')
+    })
+
+    it('negates and excludes queries', () => {
+      expect(new WasmSearchQuery().query('cancer').negate().build()).toBe('NOT (cancer)')
+
+      const base = new WasmSearchQuery().query('cancer treatment')
+      const animal = new WasmSearchQuery().query('animal studies')
+      expect(base.exclude(animal).build()).toBe('(cancer treatment) NOT (animal studies)')
+    })
+
+    it('groups a query in parentheses', () => {
+      expect(new WasmSearchQuery().query('cancer').group().build()).toBe('(cancer)')
+    })
+
+    it('does not consume the operands of a boolean combination', () => {
+      const a = new WasmSearchQuery().query('a')
+      const b = new WasmSearchQuery().query('b')
+      const combined = a.and(b)
+      // a/b take &self, so they remain usable afterwards.
+      expect(a.build()).toBe('a')
+      expect(b.build()).toBe('b')
+      expect(combined.build()).toBe('(a) AND (b)')
+    })
+  })
+})


### PR DESCRIPTION
The WASM bindings lagged behind the NAPI bindings. Bring the query builder to
parity and fill gaps in the client API.

WasmSearchQuery now exposes:
- field filters: terms, abstract_contains, has_abstract, journal_abbreviation,
  grant_number, isbn, issn, last_author, affiliation, orcid, mesh_terms,
  mesh_subheading, custom_filter
- study population: animal_studies_only, age_group, organism_mesh
- multiple article types via article_types_str (OR logic)
- dates: published_in_year, published_before, published_between
- result limit: limit / get_limit
- boolean composition: and, or, negate, exclude, group (return a new query,
  do not consume operands)

WasmPubMedClient now exposes:
- fetch_pmc_as_markdown(pmcid, options) — one-call fetch + Markdown conversion
  with configurable options
- is_oa_subset(pmcid) — Open Access subset availability info

Also refactor the article-type alias normalization into a shared helper,
add offline builder tests, and document the new API in the README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016sMX9f1eVLUyRWWN1MTX8F