### PR TITLE
feat: add Europe PMC client (core crate)

### DIFF
--- a/pubmed-client/Cargo.toml
+++ b/pubmed-client/Cargo.toml
@@ -127,6 +127,10 @@ path = "tests/integration/mocked/search_options.rs"
 name = "mocked_rate_limiting"
 path = "tests/integration/mocked/rate_limiting.rs"
 
+[[test]]
+name = "mocked_europe_pmc"
+path = "tests/integration/mocked/europe_pmc.rs"
+
 # --- API tests (opt-in, require network + PUBMED_REAL_API_TESTS=1) ---
 
 [[test]]
@@ -152,6 +156,10 @@ path = "tests/integration/api/batch_fetch.rs"
 [[test]]
 name = "api_webenv"
 path = "tests/integration/api/webenv.rs"
+
+[[test]]
+name = "api_europe_pmc"
+path = "tests/integration/api/europe_pmc.rs"
 
 [[test]]
 name = "mocked_epost"

--- a/pubmed-client/src/europe_pmc/citations.rs
+++ b/pubmed-client/src/europe_pmc/citations.rs
@@ -1,0 +1,59 @@
+//! Europe PMC `citations` endpoint operations (page-number pagination).
+
+use tracing::instrument;
+
+use pubmed_parser::europe_pmc::{
+    EuropePmcCitation, EuropePmcCitationList, parse_citations_response,
+};
+
+use crate::error::Result;
+
+use super::client::EuropePmcClient;
+use super::id::EuropePmcId;
+use super::references::DEFAULT_PAGE_SIZE;
+
+impl EuropePmcClient {
+    /// Fetch a single page of the citation list (citing articles) for a record.
+    #[instrument(skip(self), fields(id = %id, page, page_size))]
+    pub async fn get_citations_page(
+        &self,
+        id: &EuropePmcId,
+        page: u32,
+        page_size: u32,
+    ) -> Result<EuropePmcCitationList> {
+        let endpoint = format!("{}/{}/citations", id.source, id.id);
+        let page = page.to_string();
+        let page_size = page_size.to_string();
+        let response = self
+            .executor()
+            .get_endpoint(
+                &self.base_url,
+                &endpoint,
+                &[
+                    ("format", "json"),
+                    ("page", page.as_str()),
+                    ("pageSize", page_size.as_str()),
+                ],
+            )
+            .await?;
+        let text = response.text().await?;
+        Ok(parse_citations_response(&text)?)
+    }
+
+    /// Fetch all citing articles for a record, following page numbers until exhausted.
+    #[instrument(skip(self), fields(id = %id))]
+    pub async fn get_citations(&self, id: &EuropePmcId) -> Result<Vec<EuropePmcCitation>> {
+        let mut collected = Vec::new();
+        let mut page = 1;
+        loop {
+            let list = self.get_citations_page(id, page, DEFAULT_PAGE_SIZE).await?;
+            let count = list.citations.len();
+            collected.extend(list.citations);
+            if count < DEFAULT_PAGE_SIZE as usize || collected.len() as u64 >= list.hit_count {
+                break;
+            }
+            page += 1;
+        }
+        Ok(collected)
+    }
+}

--- a/pubmed-client/src/europe_pmc/client.rs
+++ b/pubmed-client/src/europe_pmc/client.rs
@@ -1,0 +1,155 @@
+//! Core [`EuropePmcClient`] definition and shared plumbing.
+
+use std::time::Duration;
+
+use reqwest::Client;
+use tracing::info;
+
+use crate::cache::{PmcCache, create_cache};
+use crate::config::ClientConfig;
+use crate::rate_limit::RateLimiter;
+use crate::request::RequestExecutor;
+
+/// Base URL for the Europe PMC RESTful Web Service.
+///
+/// Europe PMC is hosted by EBI on a different host and path scheme from the
+/// NCBI E-utilities, so it deliberately does **not** reuse
+/// [`ClientConfig::base_url`] (which is the NCBI eutils override). Use
+/// [`EuropePmcClient::with_base_url`] to point at a proxy or mock server.
+pub(crate) const EUROPE_PMC_BASE_URL: &str = "https://www.ebi.ac.uk/europepmc/webservices/rest";
+
+/// Client for the Europe PMC REST API.
+///
+/// Provides cross-source search, JATS full-text retrieval, reference and
+/// citation graphs, external database links, and supplementary file downloads.
+/// No API key is required; transport-level configuration (timeout, user agent,
+/// retry, rate limiting, caching) is shared with the rest of the workspace via
+/// [`ClientConfig`].
+///
+/// # Example
+///
+/// ```no_run
+/// use pubmed_client::europe_pmc::{EuropePmcClient, EuropePmcId};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EuropePmcClient::new();
+///     let results = client.search("malaria vaccine", 10).await?;
+///     for r in &results {
+///         println!("{}/{}: {}", r.source, r.id, r.title.as_deref().unwrap_or(""));
+///     }
+///
+///     let article = client.fetch_full_text(&EuropePmcId::pmc("PMC3258128")?).await?;
+///     println!("Title: {}", article.title().unwrap_or("Untitled"));
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone)]
+pub struct EuropePmcClient {
+    pub(crate) client: Client,
+    pub(crate) base_url: String,
+    pub(crate) rate_limiter: RateLimiter,
+    pub(crate) config: ClientConfig,
+    /// Cache for parsed full-text articles only (keyed by `epmc-ft:<source>:<id>`).
+    pub(crate) cache: Option<PmcCache>,
+}
+
+impl EuropePmcClient {
+    /// Create a new Europe PMC client with default configuration.
+    pub fn new() -> Self {
+        Self::with_config(ClientConfig::new())
+    }
+
+    /// Create a new Europe PMC client with custom configuration.
+    ///
+    /// Transport settings (timeout, user agent, retry, rate limit, cache) are
+    /// taken from `config`. The NCBI-specific `base_url` field is ignored; the
+    /// Europe PMC base URL is used instead.
+    pub fn with_config(config: ClientConfig) -> Self {
+        let rate_limiter = config.create_rate_limiter();
+
+        // reqwest's builder only fails if the TLS backend cannot be initialized,
+        // which is an unrecoverable process-level error, so this infallible
+        // constructor is allowed to `expect`.
+        #[allow(clippy::expect_used)]
+        let client = {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Client::builder()
+                    .user_agent(config.effective_user_agent())
+                    .timeout(Duration::from_secs(config.timeout.as_secs()))
+                    .build()
+                    .expect("Failed to create HTTP client")
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            {
+                Client::builder()
+                    .user_agent(config.effective_user_agent())
+                    .build()
+                    .expect("Failed to create HTTP client")
+            }
+        };
+
+        let cache = config.cache_config.as_ref().map(create_cache);
+
+        Self {
+            client,
+            base_url: EUROPE_PMC_BASE_URL.to_string(),
+            rate_limiter,
+            cache,
+            config,
+        }
+    }
+
+    /// Create a new Europe PMC client with a custom HTTP client and default config.
+    pub fn with_client(client: Client) -> Self {
+        let config = ClientConfig::new();
+        let rate_limiter = config.create_rate_limiter();
+
+        Self {
+            client,
+            base_url: EUROPE_PMC_BASE_URL.to_string(),
+            rate_limiter,
+            cache: None,
+            config,
+        }
+    }
+
+    /// Override the base URL (e.g. to target a proxy or a wiremock test server).
+    pub fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
+    }
+
+    /// Clear the full-text cache, if one is configured.
+    pub async fn clear_cache(&self) {
+        if let Some(cache) = &self.cache {
+            cache.clear().await;
+            info!("Cleared Europe PMC full-text cache");
+        }
+    }
+
+    /// Return the number of cached full-text entries (best-effort).
+    pub fn cache_entry_count(&self) -> u64 {
+        self.cache.as_ref().map_or(0, |cache| cache.entry_count())
+    }
+
+    /// Flush pending cache operations (useful in tests).
+    pub async fn sync_cache(&self) {
+        if let Some(cache) = &self.cache {
+            cache.sync().await;
+        }
+    }
+
+    /// Build a request executor borrowing this client's HTTP client, rate limiter, and config.
+    pub(crate) fn executor(&self) -> RequestExecutor<'_> {
+        RequestExecutor::new(&self.client, &self.rate_limiter, &self.config)
+    }
+}
+
+impl Default for EuropePmcClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/pubmed-client/src/europe_pmc/fulltext.rs
+++ b/pubmed-client/src/europe_pmc/fulltext.rs
@@ -1,0 +1,65 @@
+//! Europe PMC full-text (JATS XML) retrieval.
+
+use tracing::{info, instrument};
+
+use pubmed_parser::ParseError;
+use pubmed_parser::pmc::PmcArticle;
+use pubmed_parser::pmc::parser::parse_pmc_xml;
+
+use crate::error::Result;
+
+use super::client::EuropePmcClient;
+use super::id::EuropePmcId;
+
+impl EuropePmcClient {
+    /// Fetch and parse the full text of a Europe PMC record into a [`PmcArticle`].
+    ///
+    /// Europe PMC serves full text as JATS XML, which is parsed by the same
+    /// parser used for NCBI PMC. Parsing into a [`PmcArticle`] requires a PMC id,
+    /// so this method only supports `PMC`-sourced records; for other sources use
+    /// [`EuropePmcClient::fetch_full_text_xml`] to get the raw JATS instead.
+    ///
+    /// Results are cached when a cache is configured (key `epmc-ft:<source>:<id>`).
+    ///
+    /// # Errors
+    ///
+    /// * [`ParseError::PmcNotAvailable`] — the record is not PMC-sourced.
+    /// * [`crate::PubMedError::ApiError`] — the HTTP request failed.
+    #[instrument(skip(self), fields(id = %id))]
+    pub async fn fetch_full_text(&self, id: &EuropePmcId) -> Result<PmcArticle> {
+        let Some(pmcid) = id.pmcid() else {
+            return Err(ParseError::PmcNotAvailable { id: id.to_string() }.into());
+        };
+
+        let cache_key = format!("epmc-ft:{}:{}", id.source, id.id);
+        if let Some(cache) = &self.cache
+            && let Some(cached) = cache.get(&cache_key).await
+        {
+            info!(id = %id, "Cache hit for Europe PMC full text");
+            return Ok(cached);
+        }
+
+        let xml = self.fetch_full_text_xml(id).await?;
+        let article = parse_pmc_xml(&xml, &pmcid)?;
+
+        if let Some(cache) = &self.cache {
+            cache.insert(cache_key, article.clone()).await;
+        }
+
+        Ok(article)
+    }
+
+    /// Fetch the raw JATS XML full text for a Europe PMC record.
+    ///
+    /// Works for any source that has full text available. Returns the response
+    /// body verbatim (`/{source}/{id}/fullTextXML`).
+    #[instrument(skip(self), fields(id = %id))]
+    pub async fn fetch_full_text_xml(&self, id: &EuropePmcId) -> Result<String> {
+        let endpoint = format!("{}/{}/fullTextXML", id.source, id.id);
+        let response = self
+            .executor()
+            .get_endpoint(&self.base_url, &endpoint, &[])
+            .await?;
+        Ok(response.text().await?)
+    }
+}

--- a/pubmed-client/src/europe_pmc/id.rs
+++ b/pubmed-client/src/europe_pmc/id.rs
@@ -1,0 +1,210 @@
+//! Source/identifier addressing for Europe PMC records.
+//!
+//! Europe PMC addresses every record by a `(source, id)` pair, e.g.
+//! `MED/12345`, `PMC/PMC3258128`, or `PPR/PPR123456`. These types provide a
+//! typed, validated way to construct those addresses for the REST API.
+
+use std::fmt;
+use std::str::FromStr;
+
+use crate::common::PmcId;
+use crate::error::{PubMedError, Result};
+
+/// A Europe PMC source database.
+///
+/// The known variants cover the commonly used databases; any unrecognized code
+/// is preserved in [`EuropePmcSource::Other`] so new sources never break
+/// parsing or addressing.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EuropePmcSource {
+    /// PubMed / MEDLINE (`MED`).
+    Med,
+    /// PubMed Central (`PMC`).
+    Pmc,
+    /// Preprints (`PPR`).
+    Ppr,
+    /// Agricola (`AGR`).
+    Agr,
+    /// Chinese Biological Abstracts (`CBA`).
+    Cba,
+    /// Patents (`PAT`).
+    Pat,
+    /// NHS Evidence / ETHoS / other recognized-but-uncommon, or any code not
+    /// otherwise modelled. Stores the raw uppercase source code.
+    Other(String),
+}
+
+impl EuropePmcSource {
+    /// Return the uppercase source code used by the REST API (e.g. `"MED"`).
+    pub fn as_str(&self) -> &str {
+        match self {
+            EuropePmcSource::Med => "MED",
+            EuropePmcSource::Pmc => "PMC",
+            EuropePmcSource::Ppr => "PPR",
+            EuropePmcSource::Agr => "AGR",
+            EuropePmcSource::Cba => "CBA",
+            EuropePmcSource::Pat => "PAT",
+            EuropePmcSource::Other(code) => code,
+        }
+    }
+}
+
+impl fmt::Display for EuropePmcSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for EuropePmcSource {
+    // Parsing is in fact infallible (unknown codes map to `Other`), but the
+    // crate `Result` alias fixes the error type to `PubMedError`, so we use it
+    // for consistency and to satisfy the `absolute_paths` lint.
+    type Err = PubMedError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let upper = s.trim().to_ascii_uppercase();
+        Ok(match upper.as_str() {
+            "MED" => EuropePmcSource::Med,
+            "PMC" => EuropePmcSource::Pmc,
+            "PPR" => EuropePmcSource::Ppr,
+            "AGR" => EuropePmcSource::Agr,
+            "CBA" => EuropePmcSource::Cba,
+            "PAT" => EuropePmcSource::Pat,
+            _ => EuropePmcSource::Other(upper),
+        })
+    }
+}
+
+impl From<&str> for EuropePmcSource {
+    fn from(s: &str) -> Self {
+        // FromStr never returns Err for a source code.
+        s.parse()
+            .unwrap_or_else(|_| EuropePmcSource::Other(s.trim().to_ascii_uppercase()))
+    }
+}
+
+/// A fully-qualified Europe PMC record address: a `(source, id)` pair.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EuropePmcId {
+    /// The source database.
+    pub source: EuropePmcSource,
+    /// The record identifier within that source (e.g. a PMID for `MED`, or a
+    /// `PMCnnn` id for `PMC`).
+    pub id: String,
+}
+
+impl EuropePmcId {
+    /// Construct an address from an explicit source and id.
+    pub fn new(source: EuropePmcSource, id: impl Into<String>) -> Self {
+        Self {
+            source,
+            id: id.into(),
+        }
+    }
+
+    /// Construct a `PMC`-sourced address, normalizing the id to `PMCnnn` form.
+    ///
+    /// Accepts ids with or without the `PMC` prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the id is not a valid PMC id.
+    pub fn pmc(id: &str) -> Result<Self> {
+        let pmc_id = PmcId::parse(id)?;
+        Ok(Self {
+            source: EuropePmcSource::Pmc,
+            id: pmc_id.as_str(),
+        })
+    }
+
+    /// Construct a `MED`-sourced (PubMed) address from a PMID.
+    pub fn med(pmid: impl Into<String>) -> Self {
+        Self {
+            source: EuropePmcSource::Med,
+            id: pmid.into(),
+        }
+    }
+
+    /// Return the PMC id (`PMCnnn`) for this address if it is PMC-sourced.
+    pub(crate) fn pmcid(&self) -> Option<String> {
+        match self.source {
+            EuropePmcSource::Pmc => Some(self.id.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for EuropePmcId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.source, self.id)
+    }
+}
+
+impl FromStr for EuropePmcId {
+    type Err = PubMedError;
+
+    /// Parse a `"SOURCE/ID"` string, e.g. `"PMC/PMC3258128"` or `"MED/12345"`.
+    fn from_str(s: &str) -> Result<Self> {
+        let (source, id) = s.trim().split_once('/').ok_or_else(|| {
+            PubMedError::InvalidQuery(format!(
+                "invalid Europe PMC id {s:?}: expected \"SOURCE/ID\" form"
+            ))
+        })?;
+        if id.is_empty() {
+            return Err(PubMedError::InvalidQuery(format!(
+                "invalid Europe PMC id {s:?}: empty record id"
+            )));
+        }
+        Ok(Self {
+            source: EuropePmcSource::from(source),
+            id: id.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_source_roundtrip() {
+        assert_eq!(EuropePmcSource::Med.as_str(), "MED");
+        assert_eq!(
+            "pmc".parse::<EuropePmcSource>().unwrap(),
+            EuropePmcSource::Pmc
+        );
+        assert_eq!(
+            "xyz".parse::<EuropePmcSource>().unwrap(),
+            EuropePmcSource::Other("XYZ".to_string())
+        );
+    }
+
+    #[test]
+    fn test_pmc_normalizes() {
+        let id = EuropePmcId::pmc("3258128").unwrap();
+        assert_eq!(id.source, EuropePmcSource::Pmc);
+        assert_eq!(id.id, "PMC3258128");
+        assert_eq!(id.to_string(), "PMC/PMC3258128");
+        assert_eq!(id.pmcid().as_deref(), Some("PMC3258128"));
+    }
+
+    #[test]
+    fn test_med_has_no_pmcid() {
+        let id = EuropePmcId::med("12345");
+        assert_eq!(id.to_string(), "MED/12345");
+        assert!(id.pmcid().is_none());
+    }
+
+    #[test]
+    fn test_parse_from_str() {
+        let id: EuropePmcId = "PMC/PMC3258128".parse().unwrap();
+        assert_eq!(id.source, EuropePmcSource::Pmc);
+        assert_eq!(id.id, "PMC3258128");
+
+        let med: EuropePmcId = "MED/12345".parse().unwrap();
+        assert_eq!(med.source, EuropePmcSource::Med);
+
+        assert!("nodelimiter".parse::<EuropePmcId>().is_err());
+        assert!("PMC/".parse::<EuropePmcId>().is_err());
+    }
+}

--- a/pubmed-client/src/europe_pmc/links.rs
+++ b/pubmed-client/src/europe_pmc/links.rs
@@ -1,0 +1,61 @@
+//! Europe PMC `databaseLinks` endpoint operations.
+
+use tracing::instrument;
+
+use pubmed_parser::europe_pmc::{
+    EuropePmcDatabaseLink, EuropePmcDatabaseLinkList, parse_database_links_response,
+};
+
+use crate::error::Result;
+
+use super::client::EuropePmcClient;
+use super::id::EuropePmcId;
+use super::references::DEFAULT_PAGE_SIZE;
+
+impl EuropePmcClient {
+    /// Fetch a single page of external database cross-references for a record.
+    #[instrument(skip(self), fields(id = %id, page, page_size))]
+    pub async fn get_database_links_page(
+        &self,
+        id: &EuropePmcId,
+        page: u32,
+        page_size: u32,
+    ) -> Result<EuropePmcDatabaseLinkList> {
+        let endpoint = format!("{}/{}/databaseLinks", id.source, id.id);
+        let page = page.to_string();
+        let page_size = page_size.to_string();
+        let response = self
+            .executor()
+            .get_endpoint(
+                &self.base_url,
+                &endpoint,
+                &[
+                    ("format", "json"),
+                    ("page", page.as_str()),
+                    ("pageSize", page_size.as_str()),
+                ],
+            )
+            .await?;
+        let text = response.text().await?;
+        Ok(parse_database_links_response(&text)?)
+    }
+
+    /// Fetch all external database cross-references for a record.
+    #[instrument(skip(self), fields(id = %id))]
+    pub async fn get_database_links(&self, id: &EuropePmcId) -> Result<Vec<EuropePmcDatabaseLink>> {
+        let mut collected = Vec::new();
+        let mut page = 1;
+        loop {
+            let list = self
+                .get_database_links_page(id, page, DEFAULT_PAGE_SIZE)
+                .await?;
+            let count = list.links.len();
+            collected.extend(list.links);
+            if count < DEFAULT_PAGE_SIZE as usize || collected.len() as u64 >= list.hit_count {
+                break;
+            }
+            page += 1;
+        }
+        Ok(collected)
+    }
+}

--- a/pubmed-client/src/europe_pmc/mod.rs
+++ b/pubmed-client/src/europe_pmc/mod.rs
@@ -1,0 +1,32 @@
+//! Europe PMC REST API client.
+//!
+//! [`EuropePmcClient`] talks to the Europe PMC RESTful Web Service
+//! (<https://europepmc.org/RestfulWebService>), a complementary data source to
+//! the NCBI E-utilities. It offers cross-source search (PubMed/`MED`, PMC,
+//! preprints/`PPR`, patents, ...), JATS full-text retrieval, reference and
+//! citation graphs, external database links, and supplementary file downloads.
+//!
+//! Records are addressed by a `(source, id)` pair via [`EuropePmcId`]. JSON
+//! response models live in [`pubmed_parser::europe_pmc`] and are re-exported
+//! from the crate root; full text reuses the JATS [`pubmed_parser::pmc::PmcArticle`].
+
+mod citations;
+mod client;
+mod fulltext;
+mod id;
+mod links;
+mod references;
+mod search;
+#[cfg(not(target_arch = "wasm32"))]
+mod supplementary;
+
+pub use client::EuropePmcClient;
+pub use id::{EuropePmcId, EuropePmcSource};
+pub use search::{EuropePmcSearchOptions, ResultType};
+
+// Re-export the parser-side response/result models for convenience.
+pub use pubmed_parser::europe_pmc::{
+    EuropePmcCitation, EuropePmcCitationList, EuropePmcDatabaseLink, EuropePmcDatabaseLinkList,
+    EuropePmcDbCrossReferenceInfo, EuropePmcReference, EuropePmcReferenceList, EuropePmcResult,
+    EuropePmcSearchResponse,
+};

--- a/pubmed-client/src/europe_pmc/references.rs
+++ b/pubmed-client/src/europe_pmc/references.rs
@@ -1,0 +1,63 @@
+//! Europe PMC `references` endpoint operations (page-number pagination).
+
+use tracing::instrument;
+
+use pubmed_parser::europe_pmc::{
+    EuropePmcReference, EuropePmcReferenceList, parse_references_response,
+};
+
+use crate::error::Result;
+
+use super::client::EuropePmcClient;
+use super::id::EuropePmcId;
+
+/// Default page size for reference/citation pagination.
+pub(crate) const DEFAULT_PAGE_SIZE: u32 = 100;
+
+impl EuropePmcClient {
+    /// Fetch a single page of the reference list (works cited) for a record.
+    #[instrument(skip(self), fields(id = %id, page, page_size))]
+    pub async fn get_references_page(
+        &self,
+        id: &EuropePmcId,
+        page: u32,
+        page_size: u32,
+    ) -> Result<EuropePmcReferenceList> {
+        let endpoint = format!("{}/{}/references", id.source, id.id);
+        let page = page.to_string();
+        let page_size = page_size.to_string();
+        let response = self
+            .executor()
+            .get_endpoint(
+                &self.base_url,
+                &endpoint,
+                &[
+                    ("format", "json"),
+                    ("page", page.as_str()),
+                    ("pageSize", page_size.as_str()),
+                ],
+            )
+            .await?;
+        let text = response.text().await?;
+        Ok(parse_references_response(&text)?)
+    }
+
+    /// Fetch all references for a record, following page numbers until exhausted.
+    #[instrument(skip(self), fields(id = %id))]
+    pub async fn get_references(&self, id: &EuropePmcId) -> Result<Vec<EuropePmcReference>> {
+        let mut collected = Vec::new();
+        let mut page = 1;
+        loop {
+            let list = self
+                .get_references_page(id, page, DEFAULT_PAGE_SIZE)
+                .await?;
+            let count = list.references.len();
+            collected.extend(list.references);
+            if count < DEFAULT_PAGE_SIZE as usize || collected.len() as u64 >= list.hit_count {
+                break;
+            }
+            page += 1;
+        }
+        Ok(collected)
+    }
+}

--- a/pubmed-client/src/europe_pmc/search.rs
+++ b/pubmed-client/src/europe_pmc/search.rs
@@ -1,0 +1,140 @@
+//! Europe PMC `search` endpoint operations (cursor-based pagination).
+
+use tracing::{debug, instrument};
+
+use pubmed_parser::europe_pmc::{EuropePmcResult, EuropePmcSearchResponse, parse_search_response};
+
+use crate::error::Result;
+
+use super::client::EuropePmcClient;
+
+/// The level of detail returned by the Europe PMC `search` endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResultType {
+    /// Identifiers only.
+    IdList,
+    /// Core bibliographic fields (default).
+    Lite,
+    /// Full metadata including abstracts, MeSH, full author/affiliation data.
+    Core,
+}
+
+impl ResultType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ResultType::IdList => "idlist",
+            ResultType::Lite => "lite",
+            ResultType::Core => "core",
+        }
+    }
+}
+
+/// Options controlling a single Europe PMC `search` request.
+#[derive(Debug, Clone)]
+pub struct EuropePmcSearchOptions {
+    /// Level of detail to return.
+    pub result_type: ResultType,
+    /// Number of results per page (Europe PMC caps this at 1000).
+    pub page_size: u32,
+    /// Cursor mark for the page to fetch. Use `"*"` for the first page.
+    pub cursor_mark: String,
+    /// Optional sort expression (e.g. `"P_PDATE_D desc"`, `"CITED desc"`).
+    pub sort: Option<String>,
+}
+
+impl Default for EuropePmcSearchOptions {
+    fn default() -> Self {
+        Self {
+            result_type: ResultType::Lite,
+            page_size: 25,
+            cursor_mark: "*".to_string(),
+            sort: None,
+        }
+    }
+}
+
+impl EuropePmcClient {
+    /// Search Europe PMC and return up to `limit` lite results.
+    ///
+    /// Convenience wrapper over [`EuropePmcClient::search_all`] using
+    /// [`ResultType::Lite`]. For cursor control or `core` detail, use
+    /// [`EuropePmcClient::search_page`] / [`EuropePmcClient::search_all`].
+    #[instrument(skip(self), fields(query = %query, limit))]
+    pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<EuropePmcResult>> {
+        let opts = EuropePmcSearchOptions {
+            page_size: limit.clamp(1, 1000) as u32,
+            ..Default::default()
+        };
+        self.search_all(query, limit, &opts).await
+    }
+
+    /// Fetch a single page of search results.
+    ///
+    /// The returned [`EuropePmcSearchResponse::next_cursor_mark`] is the cursor
+    /// to pass back via `opts.cursor_mark` to fetch the following page.
+    #[instrument(skip(self, opts), fields(query = %query, cursor = %opts.cursor_mark))]
+    pub async fn search_page(
+        &self,
+        query: &str,
+        opts: &EuropePmcSearchOptions,
+    ) -> Result<EuropePmcSearchResponse> {
+        let page_size = opts.page_size.to_string();
+        let mut params: Vec<(&str, &str)> = vec![
+            ("query", query),
+            ("format", "json"),
+            ("resultType", opts.result_type.as_str()),
+            ("pageSize", page_size.as_str()),
+            ("cursorMark", opts.cursor_mark.as_str()),
+        ];
+        if let Some(sort) = &opts.sort {
+            params.push(("sort", sort.as_str()));
+        }
+
+        let response = self
+            .executor()
+            .get_endpoint(&self.base_url, "search", &params)
+            .await?;
+        let text = response.text().await?;
+        Ok(parse_search_response(&text)?)
+    }
+
+    /// Fetch search results across pages until `max_results` is reached or the
+    /// result set is exhausted.
+    ///
+    /// Follows the `nextCursorMark` chain. Europe PMC signals the end of results
+    /// by returning the same cursor it was given, so the loop also stops when the
+    /// cursor stops advancing.
+    #[instrument(skip(self, opts), fields(query = %query, max_results))]
+    pub async fn search_all(
+        &self,
+        query: &str,
+        max_results: usize,
+        opts: &EuropePmcSearchOptions,
+    ) -> Result<Vec<EuropePmcResult>> {
+        let mut collected: Vec<EuropePmcResult> = Vec::new();
+        let mut cursor = opts.cursor_mark.clone();
+
+        while collected.len() < max_results {
+            let page_opts = EuropePmcSearchOptions {
+                cursor_mark: cursor.clone(),
+                ..opts.clone()
+            };
+            let page = self.search_page(query, &page_opts).await?;
+
+            if page.results.is_empty() {
+                break;
+            }
+            collected.extend(page.results);
+
+            match page.next_cursor_mark {
+                // Cursor stopped advancing => last page reached.
+                Some(next) if next != cursor => cursor = next,
+                _ => break,
+            }
+        }
+
+        collected.truncate(max_results);
+        debug!(returned = collected.len(), "Europe PMC search_all complete");
+        Ok(collected)
+    }
+}

--- a/pubmed-client/src/europe_pmc/supplementary.rs
+++ b/pubmed-client/src/europe_pmc/supplementary.rs
@@ -1,0 +1,63 @@
+//! Europe PMC `supplementaryFiles` endpoint operations (native only).
+//!
+//! Europe PMC returns supplementary materials as a single ZIP archive. These
+//! helpers fetch that archive either into memory or onto disk; ZIP extraction is
+//! left to the caller to avoid pulling in an archive dependency.
+
+use std::path::{Path, PathBuf};
+
+use tokio::fs as tokio_fs;
+use tracing::{info, instrument};
+
+use pubmed_parser::ParseError;
+
+use crate::error::{PubMedError, Result};
+
+use super::client::EuropePmcClient;
+use super::id::EuropePmcId;
+
+impl EuropePmcClient {
+    /// Fetch the supplementary-files ZIP archive for a record into memory.
+    ///
+    /// Returns the raw bytes of the ZIP (`/{source}/{id}/supplementaryFiles`).
+    #[instrument(skip(self), fields(id = %id))]
+    pub async fn fetch_supplementary_files(&self, id: &EuropePmcId) -> Result<Vec<u8>> {
+        let endpoint = format!("{}/{}/supplementaryFiles", id.source, id.id);
+        let response = self
+            .executor()
+            .get_endpoint(&self.base_url, &endpoint, &[])
+            .await?;
+        let bytes = response.bytes().await.map_err(PubMedError::from)?;
+        Ok(bytes.to_vec())
+    }
+
+    /// Download the supplementary-files ZIP archive for a record to `output_path`.
+    ///
+    /// `output_path` is the full path of the ZIP file to write. Parent
+    /// directories are created if needed. Returns the written path.
+    #[instrument(skip(self, output_path), fields(id = %id))]
+    pub async fn download_supplementary_files(
+        &self,
+        id: &EuropePmcId,
+        output_path: impl AsRef<Path>,
+    ) -> Result<PathBuf> {
+        let output_path = output_path.as_ref().to_path_buf();
+        if let Some(parent) = output_path.parent() {
+            tokio_fs::create_dir_all(parent)
+                .await
+                .map_err(|e| ParseError::IoError {
+                    message: format!("failed to create directory {}: {e}", parent.display()),
+                })?;
+        }
+
+        let bytes = self.fetch_supplementary_files(id).await?;
+        tokio_fs::write(&output_path, &bytes)
+            .await
+            .map_err(|e| ParseError::IoError {
+                message: format!("failed to write {}: {e}", output_path.display()),
+            })?;
+
+        info!(id = %id, path = %output_path.display(), bytes = bytes.len(), "Downloaded supplementary files");
+        Ok(output_path)
+    }
+}

--- a/pubmed-client/src/lib.rs
+++ b/pubmed-client/src/lib.rs
@@ -265,6 +265,7 @@
 pub mod cache;
 pub mod config;
 pub mod error;
+pub mod europe_pmc;
 pub mod pmc;
 pub mod pubmed;
 pub mod rate_limit;
@@ -280,6 +281,12 @@ pub(crate) use pubmed_parser::common;
 pub use common::{Affiliation, Author, PmcId, PubMedId};
 pub use config::ClientConfig;
 pub use error::{ParseError, PubMedError, Result};
+pub use europe_pmc::{
+    EuropePmcCitation, EuropePmcCitationList, EuropePmcClient, EuropePmcDatabaseLink,
+    EuropePmcDatabaseLinkList, EuropePmcDbCrossReferenceInfo, EuropePmcId, EuropePmcReference,
+    EuropePmcReferenceList, EuropePmcResult, EuropePmcSearchOptions, EuropePmcSearchResponse,
+    EuropePmcSource, ResultType,
+};
 pub use pmc::{
     Abstract, ArticleMeta, Back, Body, ExtractedFigure, Figure, FigureOptions, Front, FundingInfo,
     HeadingStyle, JournalMeta, KeywordGroup, License, MarkdownConfig, MetadataOptions,
@@ -304,6 +311,8 @@ pub struct Client {
     pub pubmed: PubMedClient,
     /// PMC client for full text
     pub pmc: PmcClient,
+    /// Europe PMC client for cross-source search, full text, and citation graphs
+    pub europe_pmc: EuropePmcClient,
 }
 
 impl Client {
@@ -347,7 +356,8 @@ impl Client {
     pub fn with_config(config: ClientConfig) -> Self {
         Self {
             pubmed: PubMedClient::with_config(config.clone()),
-            pmc: PmcClient::with_config(config),
+            pmc: PmcClient::with_config(config.clone()),
+            europe_pmc: EuropePmcClient::with_config(config),
         }
     }
 
@@ -374,7 +384,8 @@ impl Client {
     pub fn with_http_client(http_client: reqwest::Client) -> Self {
         Self {
             pubmed: PubMedClient::with_client(http_client.clone()),
-            pmc: PmcClient::with_client(http_client),
+            pmc: PmcClient::with_client(http_client.clone()),
+            europe_pmc: EuropePmcClient::with_client(http_client),
         }
     }
 

--- a/pubmed-client/tests/integration/api/europe_pmc.rs
+++ b/pubmed-client/tests/integration/api/europe_pmc.rs
@@ -1,0 +1,109 @@
+//! Europe PMC REST API integration tests (real network).
+//!
+//! **IMPORTANT**: These tests are only run when:
+//! 1. The `integration-tests` feature is enabled
+//! 2. The `PUBMED_REAL_API_TESTS` environment variable is set
+//!
+//! ```bash
+//! PUBMED_REAL_API_TESTS=1 cargo test --features integration-tests --test api_europe_pmc
+//! ```
+
+#[path = "../common/mod.rs"]
+mod common;
+
+#[cfg(feature = "integration-tests")]
+mod integration_tests {
+    use tracing::info;
+    use tracing_test::traced_test;
+
+    use pubmed_client::europe_pmc::{EuropePmcId, EuropePmcSource};
+
+    use crate::common::integration_test_utils::{
+        create_test_europe_pmc_client, should_run_real_api_tests,
+    };
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_search_integration() {
+        if !should_run_real_api_tests() {
+            info!("Skipping real API test - enable with PUBMED_REAL_API_TESTS=1");
+            return;
+        }
+
+        let client = create_test_europe_pmc_client();
+        let results = client
+            .search("malaria vaccine", 5)
+            .await
+            .expect("search should succeed");
+
+        assert!(!results.is_empty(), "expected at least one result");
+        assert!(results.len() <= 5);
+        assert!(results.iter().all(|r| !r.source.is_empty()));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_fetch_full_text_integration() {
+        if !should_run_real_api_tests() {
+            info!("Skipping real API test - enable with PUBMED_REAL_API_TESTS=1");
+            return;
+        }
+
+        let client = create_test_europe_pmc_client();
+        // PMC3258128 is the canonical Europe PMC fullTextXML example.
+        let id = EuropePmcId::pmc("PMC3258128").unwrap();
+        let article = client
+            .fetch_full_text(&id)
+            .await
+            .expect("full text should fetch and parse");
+        assert!(article.title().is_some());
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_references_and_citations_integration() {
+        if !should_run_real_api_tests() {
+            info!("Skipping real API test - enable with PUBMED_REAL_API_TESTS=1");
+            return;
+        }
+
+        let client = create_test_europe_pmc_client();
+        let id = EuropePmcId::new(EuropePmcSource::Med, "23245604");
+
+        let references = client
+            .get_references(&id)
+            .await
+            .expect("references should fetch");
+        assert!(!references.is_empty(), "expected at least one reference");
+
+        let citations = client
+            .get_citations(&id)
+            .await
+            .expect("citations should fetch");
+        // Citation count can legitimately be zero for some articles; just assert
+        // the request succeeded and any returned entries are well-formed.
+        assert!(
+            citations
+                .iter()
+                .all(|c| c.id.is_some() || c.title.is_some())
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_database_links_integration() {
+        if !should_run_real_api_tests() {
+            info!("Skipping real API test - enable with PUBMED_REAL_API_TESTS=1");
+            return;
+        }
+
+        let client = create_test_europe_pmc_client();
+        let id = EuropePmcId::new(EuropePmcSource::Med, "23245604");
+        let links = client
+            .get_database_links(&id)
+            .await
+            .expect("database links should fetch");
+        // Some records have no external DB links; assert structure if present.
+        assert!(links.iter().all(|l| l.db_name.is_some()));
+    }
+}

--- a/pubmed-client/tests/integration/common/integration_test_utils.rs
+++ b/pubmed-client/tests/integration/common/integration_test_utils.rs
@@ -3,6 +3,7 @@
 
 #![allow(dead_code)]
 
+use pubmed_client::europe_pmc::EuropePmcClient;
 use pubmed_client::{Client, ClientConfig, PmcClient, PubMedClient};
 
 /// Helper function to check if real API tests should be run
@@ -52,6 +53,18 @@ pub fn create_test_pmc_client() -> PmcClient {
     }
 
     PmcClient::with_config(config)
+}
+
+/// Create a Europe PMC-specific client for integration tests
+///
+/// Europe PMC does not use an NCBI API key; rate limiting is kept conservative.
+pub fn create_test_europe_pmc_client() -> EuropePmcClient {
+    let config = ClientConfig::new()
+        .with_email("test@example.com")
+        .with_tool("pubmed-client-europe-pmc-integration-tests")
+        .with_rate_limit(2.0);
+
+    EuropePmcClient::with_config(config)
 }
 
 /// Known PMIDs for integration testing (these are stable, well-formed articles)

--- a/pubmed-client/tests/integration/mocked/europe_pmc.rs
+++ b/pubmed-client/tests/integration/mocked/europe_pmc.rs
@@ -1,0 +1,237 @@
+//! Integration tests for the Europe PMC client using mocked HTTP responses.
+//!
+//! These exercise the client end-to-end (URL construction, pagination loops,
+//! JSON/JATS parsing, and the non-PMC full-text guard) without real network
+//! access, using wiremock.
+
+use pubmed_client::europe_pmc::{EuropePmcClient, EuropePmcId, EuropePmcSource};
+use tracing_test::traced_test;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn client(mock_server: &MockServer) -> EuropePmcClient {
+    EuropePmcClient::new().with_base_url(mock_server.uri())
+}
+
+fn json_response(body: &str) -> ResponseTemplate {
+    ResponseTemplate::new(200)
+        .set_body_string(body.to_string())
+        .insert_header("content-type", "application/json")
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_follows_cursor_across_pages() {
+    let mock_server = MockServer::start().await;
+
+    // First page (cursorMark=*) returns 2 results and advances the cursor.
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .and(query_param("cursorMark", "*"))
+        .respond_with(json_response(
+            r#"{
+                "hitCount": 3,
+                "nextCursorMark": "PAGE2",
+                "resultList": {"result": [
+                    {"id": "1", "source": "MED", "title": "First", "pubYear": "2020"},
+                    {"id": "2", "source": "PMC", "pmcid": "PMC2", "title": "Second"}
+                ]}
+            }"#,
+        ))
+        .mount(&mock_server)
+        .await;
+
+    // Second page (cursorMark=PAGE2) returns 1 result, cursor stops advancing.
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .and(query_param("cursorMark", "PAGE2"))
+        .respond_with(json_response(
+            r#"{
+                "hitCount": 3,
+                "nextCursorMark": "PAGE2",
+                "resultList": {"result": [
+                    {"id": "3", "source": "PPR", "title": "Third"}
+                ]}
+            }"#,
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let results = client(&mock_server)
+        .search("cancer", 100)
+        .await
+        .expect("search should succeed");
+
+    assert_eq!(results.len(), 3, "should collect across both pages");
+    assert_eq!(results[0].id, "1");
+    assert_eq!(results[1].pmcid.as_deref(), Some("PMC2"));
+    assert_eq!(results[2].source, "PPR");
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_search_respects_limit() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(json_response(
+            r#"{
+                "hitCount": 50,
+                "nextCursorMark": "NEXT",
+                "resultList": {"result": [
+                    {"id": "1", "source": "MED"},
+                    {"id": "2", "source": "MED"},
+                    {"id": "3", "source": "MED"}
+                ]}
+            }"#,
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let results = client(&mock_server)
+        .search("x", 2)
+        .await
+        .expect("search should succeed");
+    assert_eq!(results.len(), 2, "should truncate to the requested limit");
+}
+
+/// Minimal but structurally valid JATS, matching what Europe PMC serves from
+/// `fullTextXML`. Parsed by the same `parse_pmc_xml` used for NCBI PMC.
+const JATS_FULL_TEXT: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<article article-type="research-article">
+  <front>
+    <journal-meta>
+      <journal-title-group><journal-title>Test Journal</journal-title></journal-title-group>
+    </journal-meta>
+    <article-meta>
+      <article-id pub-id-type="pmcid">PMC10618641</article-id>
+      <article-id pub-id-type="doi">10.1000/test</article-id>
+      <title-group><article-title>A Europe PMC test article</article-title></title-group>
+    </article-meta>
+  </front>
+  <body>
+    <sec><title>Introduction</title><p>Some body text.</p></sec>
+  </body>
+</article>"#;
+
+#[tokio::test]
+#[traced_test]
+async fn test_fetch_full_text_parses_jats() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/PMC/PMC10618641/fullTextXML"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(JATS_FULL_TEXT.to_string())
+                .insert_header("content-type", "application/xml"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let id = EuropePmcId::pmc("PMC10618641").unwrap();
+    let article = client(&mock_server)
+        .fetch_full_text(&id)
+        .await
+        .expect("full text should parse");
+    assert_eq!(article.title(), Some("A Europe PMC test article"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_fetch_full_text_rejects_non_pmc_source() {
+    let mock_server = MockServer::start().await;
+    // No mock needed: the guard short-circuits before any request.
+    let id = EuropePmcId::new(EuropePmcSource::Med, "12345");
+    let err = client(&mock_server)
+        .fetch_full_text(&id)
+        .await
+        .expect_err("MED source has no PmcArticle full text");
+    assert!(
+        err.to_string().to_lowercase().contains("not available"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_get_references_paginates() {
+    let mock_server = MockServer::start().await;
+
+    // hitCount 2 but pageSize is large, so a single full page ends pagination.
+    Mock::given(method("GET"))
+        .and(path("/PMC/PMC10618641/references"))
+        .respond_with(json_response(
+            r#"{
+                "hitCount": 2,
+                "referenceList": {"reference": [
+                    {"id": 100, "title": "Ref one", "pubYear": 2010, "pmid": "100"},
+                    {"title": "Ref two", "pubYear": 1999}
+                ]}
+            }"#,
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let id = EuropePmcId::pmc("PMC10618641").unwrap();
+    let refs = client(&mock_server)
+        .get_references(&id)
+        .await
+        .expect("references should fetch");
+    assert_eq!(refs.len(), 2);
+    assert_eq!(refs[0].pub_year.as_deref(), Some("2010"));
+    assert_eq!(refs[0].id.as_deref(), Some("100"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_get_citations() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/MED/12345/citations"))
+        .respond_with(json_response(
+            r#"{
+                "hitCount": 1,
+                "citationList": {"citation": [
+                    {"id": "999", "source": "MED", "title": "Citing", "citedByCount": 4}
+                ]}
+            }"#,
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let id = EuropePmcId::med("12345");
+    let citations = client(&mock_server)
+        .get_citations(&id)
+        .await
+        .expect("citations should fetch");
+    assert_eq!(citations.len(), 1);
+    assert_eq!(citations[0].cited_by_count.as_deref(), Some("4"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_get_database_links() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/MED/12345/databaseLinks"))
+        .respond_with(json_response(
+            r#"{
+                "hitCount": 1,
+                "dbCrossReferenceList": {"dbCrossReference": [
+                    {"dbName": "UNIPROT", "dbCount": 1,
+                     "dbCrossReferenceInfo": [{"info1": "P12345"}]}
+                ]}
+            }"#,
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let id = EuropePmcId::med("12345");
+    let links = client(&mock_server)
+        .get_database_links(&id)
+        .await
+        .expect("database links should fetch");
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].db_name.as_deref(), Some("UNIPROT"));
+    assert_eq!(links[0].info[0].info1.as_deref(), Some("P12345"));
+}

--- a/pubmed-parser/src/europe_pmc/citations.rs
+++ b/pubmed-parser/src/europe_pmc/citations.rs
@@ -1,0 +1,82 @@
+//! Europe PMC `citations` endpoint response parsing.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+use super::models::EuropePmcCitation;
+
+/// Parsed response from the Europe PMC `citations` endpoint (one page).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(from = "RawCitationsResponse")]
+pub struct EuropePmcCitationList {
+    /// Total number of citing articles (across all pages).
+    pub hit_count: u64,
+    /// The citing articles on this page.
+    pub citations: Vec<EuropePmcCitation>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawCitationsResponse {
+    #[serde(default)]
+    hit_count: u64,
+    #[serde(default)]
+    citation_list: RawCitationList,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCitationList {
+    #[serde(default)]
+    citation: Vec<EuropePmcCitation>,
+}
+
+impl From<RawCitationsResponse> for EuropePmcCitationList {
+    fn from(raw: RawCitationsResponse) -> Self {
+        Self {
+            hit_count: raw.hit_count,
+            citations: raw.citation_list.citation,
+        }
+    }
+}
+
+/// Parse a Europe PMC `citations` JSON response.
+pub fn parse_citations_response(json: &str) -> Result<EuropePmcCitationList> {
+    Ok(serde_json::from_str(json)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_citations() {
+        let json = r#"{
+            "hitCount": 1,
+            "citationList": {
+                "citation": [
+                    {
+                        "id": "99999",
+                        "source": "MED",
+                        "citationType": "JOURNAL ARTICLE",
+                        "title": "A citing article",
+                        "authorString": "Roe R.",
+                        "journalAbbreviation": "Cell",
+                        "pubYear": 2020,
+                        "volume": "1",
+                        "issue": "1",
+                        "pageInfo": "1-9",
+                        "citedByCount": 7
+                    }
+                ]
+            }
+        }"#;
+
+        let resp = parse_citations_response(json).unwrap();
+        assert_eq!(resp.hit_count, 1);
+        assert_eq!(resp.citations.len(), 1);
+        assert_eq!(resp.citations[0].id.as_deref(), Some("99999"));
+        assert_eq!(resp.citations[0].pub_year.as_deref(), Some("2020"));
+        assert_eq!(resp.citations[0].cited_by_count.as_deref(), Some("7"));
+    }
+}

--- a/pubmed-parser/src/europe_pmc/de.rs
+++ b/pubmed-parser/src/europe_pmc/de.rs
@@ -1,0 +1,24 @@
+//! Custom serde deserialization helpers for Europe PMC JSON responses.
+//!
+//! Europe PMC is inconsistent about whether some scalar fields are encoded as
+//! JSON strings or JSON numbers (for example `pubYear` is a string in the
+//! `search` endpoint but a number in the `references` endpoint). These helpers
+//! normalize such fields into `Option<String>` so the domain models stay simple.
+
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize a field that may be a string, a number, a bool, or null into an
+/// `Option<String>`. Missing fields should be paired with `#[serde(default)]`.
+pub(crate) fn opt_string_flex<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(match value {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(s) => Some(s),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        other => Some(other.to_string()),
+    })
+}

--- a/pubmed-parser/src/europe_pmc/links.rs
+++ b/pubmed-parser/src/europe_pmc/links.rs
@@ -1,0 +1,82 @@
+//! Europe PMC `databaseLinks` endpoint response parsing.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+use super::models::EuropePmcDatabaseLink;
+
+/// Parsed response from the Europe PMC `databaseLinks` endpoint (one page).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(from = "RawDatabaseLinksResponse")]
+pub struct EuropePmcDatabaseLinkList {
+    /// Total number of cross-reference groups (across all pages).
+    pub hit_count: u64,
+    /// Cross-reference groups, one per external database.
+    pub links: Vec<EuropePmcDatabaseLink>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawDatabaseLinksResponse {
+    #[serde(default)]
+    hit_count: u64,
+    #[serde(default)]
+    db_cross_reference_list: RawDbCrossReferenceList,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct RawDbCrossReferenceList {
+    #[serde(default)]
+    db_cross_reference: Vec<EuropePmcDatabaseLink>,
+}
+
+impl From<RawDatabaseLinksResponse> for EuropePmcDatabaseLinkList {
+    fn from(raw: RawDatabaseLinksResponse) -> Self {
+        Self {
+            hit_count: raw.hit_count,
+            links: raw.db_cross_reference_list.db_cross_reference,
+        }
+    }
+}
+
+/// Parse a Europe PMC `databaseLinks` JSON response.
+pub fn parse_database_links_response(json: &str) -> Result<EuropePmcDatabaseLinkList> {
+    Ok(serde_json::from_str(json)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_database_links() {
+        let json = r#"{
+            "hitCount": 1,
+            "dbCrossReferenceList": {
+                "dbCrossReference": [
+                    {
+                        "dbName": "UNIPROT",
+                        "dbCount": 2,
+                        "dbCrossReferenceInfo": [
+                            {"info1": "P12345", "info2": "PROT1_HUMAN"},
+                            {"info1": "Q67890"}
+                        ]
+                    }
+                ]
+            }
+        }"#;
+
+        let resp = parse_database_links_response(json).unwrap();
+        assert_eq!(resp.hit_count, 1);
+        assert_eq!(resp.links.len(), 1);
+        let link = &resp.links[0];
+        assert_eq!(link.db_name.as_deref(), Some("UNIPROT"));
+        assert_eq!(link.db_count, Some(2));
+        assert_eq!(link.info.len(), 2);
+        assert_eq!(link.info[0].info1.as_deref(), Some("P12345"));
+        assert_eq!(link.info[0].info2.as_deref(), Some("PROT1_HUMAN"));
+        assert_eq!(link.info[1].info1.as_deref(), Some("Q67890"));
+    }
+}

--- a/pubmed-parser/src/europe_pmc/mod.rs
+++ b/pubmed-parser/src/europe_pmc/mod.rs
@@ -1,0 +1,25 @@
+//! Europe PMC REST API data models and JSON response parsers.
+//!
+//! Europe PMC (<https://europepmc.org>) is operated by EBI and aggregates
+//! literature from many sources (PubMed/`MED`, PMC, preprints/`PPR`, patents,
+//! agricultural literature, ...). Unlike the NCBI E-utilities, its REST API
+//! returns JSON for metadata endpoints and JATS XML for full text.
+//!
+//! This module provides pure, network-free parsing of the JSON responses.
+//! Full text is JATS and is parsed by [`crate::pmc::parser::parse_pmc_xml`].
+
+mod citations;
+mod de;
+mod links;
+mod models;
+mod references;
+mod search;
+
+pub use citations::{EuropePmcCitationList, parse_citations_response};
+pub use links::{EuropePmcDatabaseLinkList, parse_database_links_response};
+pub use models::{
+    EuropePmcCitation, EuropePmcDatabaseLink, EuropePmcDbCrossReferenceInfo, EuropePmcReference,
+    EuropePmcResult,
+};
+pub use references::{EuropePmcReferenceList, parse_references_response};
+pub use search::{EuropePmcSearchResponse, parse_search_response};

--- a/pubmed-parser/src/europe_pmc/models.rs
+++ b/pubmed-parser/src/europe_pmc/models.rs
@@ -1,0 +1,173 @@
+//! Domain models for Europe PMC REST API JSON responses.
+//!
+//! These mirror the item-level shapes returned by the Europe PMC RESTful Web
+//! Service (<https://europepmc.org/RestfulWebService>). They are intentionally
+//! lenient: unknown or rarely-used fields are captured in an `extra` map rather
+//! than modelled exhaustively, so new API fields never break deserialization.
+
+use serde::{Deserialize, Serialize};
+
+use super::de::opt_string_flex;
+
+/// A single search result record from the Europe PMC `search` endpoint.
+///
+/// Field coverage matches `resultType=lite`; `resultType=core` adds many more
+/// fields which are preserved in [`EuropePmcResult::extra`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EuropePmcResult {
+    /// Record identifier within its source database (e.g. a PMID for `MED`).
+    #[serde(default)]
+    pub id: String,
+    /// Source database code (`MED`, `PMC`, `PPR`, `AGR`, `CBA`, `PAT`, ...).
+    #[serde(default)]
+    pub source: String,
+    /// PubMed ID, when the record is linked to PubMed.
+    #[serde(default)]
+    pub pmid: Option<String>,
+    /// PubMed Central ID (e.g. `PMC7894017`), when full text is in PMC.
+    #[serde(default)]
+    pub pmcid: Option<String>,
+    /// Digital Object Identifier.
+    #[serde(default)]
+    pub doi: Option<String>,
+    /// Article title.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Comma-separated author list, as provided by Europe PMC.
+    #[serde(default)]
+    pub author_string: Option<String>,
+    /// Journal title.
+    #[serde(default)]
+    pub journal_title: Option<String>,
+    /// Publication year.
+    #[serde(default, deserialize_with = "opt_string_flex")]
+    pub pub_year: Option<String>,
+    /// Open access flag (`"Y"` / `"N"`).
+    #[serde(default)]
+    pub is_open_access: Option<String>,
+    /// Any additional fields not modelled above (populated for `resultType=core`).
+    #[serde(flatten, default)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// A cited reference from the Europe PMC `references` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EuropePmcReference {
+    /// Source database code of the referenced record, when matched.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Identifier of the referenced record, when matched.
+    #[serde(default, deserialize_with = "opt_string_flex")]
+    pub id: Option<String>,
+    /// Citation type (e.g. `"JOURNAL ARTICLE"`).
+    #[serde(default)]
+    pub citation_type: Option<String>,
+    /// Title of the cited work.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Comma-separated author list of the cited work.
+    #[serde(default)]
+    pub author_string: Option<String>,
+    /// Abbreviated journal name.
+    #[serde(default)]
+    pub journal_abbreviation: Option<String>,
+    /// Publication year.
+    #[serde(default, deserialize_with = "opt_string_flex")]
+    pub pub_year: Option<String>,
+    /// Journal volume.
+    #[serde(default)]
+    pub volume: Option<String>,
+    /// Journal issue.
+    #[serde(default)]
+    pub issue: Option<String>,
+    /// Page range / location.
+    #[serde(default)]
+    pub page_info: Option<String>,
+    /// PubMed ID of the cited work, when matched.
+    #[serde(default, deserialize_with = "opt_string_flex")]
+    pub pmid: Option<String>,
+    /// DOI of the cited work, when present.
+    #[serde(default)]
+    pub doi: Option<String>,
+    /// Any additional fields not modelled above.
+    #[serde(flatten, default)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// A citing article from the Europe PMC `citations` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EuropePmcCitation {
+    /// Identifier of the citing record within its source database.
+    #[serde(default, deserialize_with = "opt_string_flex")]
+    pub id: Option<String>,
+    /// Source database code of the citing record.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Citation type (e.g. `"JOURNAL ARTICLE"`).
+    #[serde(default)]
+    pub citation_type: Option<String>,
+    /// Title of the citing article.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Comma-separated author list of the citing article.
+    #[serde(default)]
+    pub author_string: Option<String>,
+    /// Abbreviated journal name.
+    #[serde(default)]
+    pub journal_abbreviation: Option<String>,
+    /// Publication year.
+    #[serde(default, deserialize_with = "opt_string_flex")]
+    pub pub_year: Option<String>,
+    /// Journal volume.
+    #[serde(default)]
+    pub volume: Option<String>,
+    /// Journal issue.
+    #[serde(default)]
+    pub issue: Option<String>,
+    /// Page range / location.
+    #[serde(default)]
+    pub page_info: Option<String>,
+    /// Number of times the citing article has itself been cited.
+    #[serde(default, deserialize_with = "opt_string_flex")]
+    pub cited_by_count: Option<String>,
+    /// Any additional fields not modelled above.
+    #[serde(flatten, default)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// A grouping of cross-references to a single external database from the
+/// Europe PMC `databaseLinks` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EuropePmcDatabaseLink {
+    /// External database name (e.g. `"UNIPROT"`, `"EMBL"`, `"PDB"`).
+    #[serde(default)]
+    pub db_name: Option<String>,
+    /// Number of cross-references to this database.
+    #[serde(default)]
+    pub db_count: Option<u32>,
+    /// Individual cross-reference entries.
+    #[serde(rename = "dbCrossReferenceInfo", default)]
+    pub info: Vec<EuropePmcDbCrossReferenceInfo>,
+}
+
+/// A single external-database cross-reference entry. The meaning of each `info`
+/// slot varies by database; Europe PMC documents them only positionally.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct EuropePmcDbCrossReferenceInfo {
+    /// First positional value (often the external accession/identifier).
+    #[serde(default)]
+    pub info1: Option<String>,
+    /// Second positional value.
+    #[serde(default)]
+    pub info2: Option<String>,
+    /// Third positional value.
+    #[serde(default)]
+    pub info3: Option<String>,
+    /// Fourth positional value.
+    #[serde(default)]
+    pub info4: Option<String>,
+}

--- a/pubmed-parser/src/europe_pmc/references.rs
+++ b/pubmed-parser/src/europe_pmc/references.rs
@@ -1,0 +1,90 @@
+//! Europe PMC `references` endpoint response parsing.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+use super::models::EuropePmcReference;
+
+/// Parsed response from the Europe PMC `references` endpoint (one page).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(from = "RawReferencesResponse")]
+pub struct EuropePmcReferenceList {
+    /// Total number of references for the article (across all pages).
+    pub hit_count: u64,
+    /// The references on this page.
+    pub references: Vec<EuropePmcReference>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawReferencesResponse {
+    #[serde(default)]
+    hit_count: u64,
+    #[serde(default)]
+    reference_list: RawReferenceList,
+}
+
+#[derive(Deserialize, Default)]
+struct RawReferenceList {
+    #[serde(default)]
+    reference: Vec<EuropePmcReference>,
+}
+
+impl From<RawReferencesResponse> for EuropePmcReferenceList {
+    fn from(raw: RawReferencesResponse) -> Self {
+        Self {
+            hit_count: raw.hit_count,
+            references: raw.reference_list.reference,
+        }
+    }
+}
+
+/// Parse a Europe PMC `references` JSON response.
+pub fn parse_references_response(json: &str) -> Result<EuropePmcReferenceList> {
+    Ok(serde_json::from_str(json)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_references() {
+        let json = r#"{
+            "hitCount": 2,
+            "referenceList": {
+                "reference": [
+                    {
+                        "id": 12345,
+                        "source": "MED",
+                        "citationType": "JOURNAL ARTICLE",
+                        "title": "Cited work one",
+                        "authorString": "Doe J.",
+                        "journalAbbreviation": "Nature",
+                        "pubYear": 2010,
+                        "volume": "5",
+                        "issue": "2",
+                        "pageInfo": "100-110",
+                        "pmid": "12345",
+                        "doi": "10.1/abc"
+                    },
+                    {
+                        "title": "Unmatched reference",
+                        "pubYear": 1999
+                    }
+                ]
+            }
+        }"#;
+
+        let resp = parse_references_response(json).unwrap();
+        assert_eq!(resp.hit_count, 2);
+        assert_eq!(resp.references.len(), 2);
+        // pubYear arrives as a JSON number but is normalized to a string.
+        assert_eq!(resp.references[0].pub_year.as_deref(), Some("2010"));
+        assert_eq!(resp.references[0].id.as_deref(), Some("12345"));
+        assert_eq!(resp.references[0].pmid.as_deref(), Some("12345"));
+        assert_eq!(resp.references[1].pub_year.as_deref(), Some("1999"));
+        assert!(resp.references[1].id.is_none());
+    }
+}

--- a/pubmed-parser/src/europe_pmc/search.rs
+++ b/pubmed-parser/src/europe_pmc/search.rs
@@ -1,0 +1,133 @@
+//! Europe PMC `search` endpoint response parsing.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+use super::models::EuropePmcResult;
+
+/// Parsed response from the Europe PMC `search` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(from = "RawSearchResponse")]
+pub struct EuropePmcSearchResponse {
+    /// Total number of records matching the query (across all pages).
+    pub hit_count: u64,
+    /// Cursor mark to pass as `cursorMark` to fetch the next page, if any.
+    /// Europe PMC keeps returning the same value once the last page is reached.
+    pub next_cursor_mark: Option<String>,
+    /// The records on this page.
+    pub results: Vec<EuropePmcResult>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawSearchResponse {
+    #[serde(default)]
+    hit_count: u64,
+    #[serde(default)]
+    next_cursor_mark: Option<String>,
+    #[serde(default)]
+    result_list: RawResultList,
+}
+
+#[derive(Deserialize, Default)]
+struct RawResultList {
+    #[serde(default)]
+    result: Vec<EuropePmcResult>,
+}
+
+impl From<RawSearchResponse> for EuropePmcSearchResponse {
+    fn from(raw: RawSearchResponse) -> Self {
+        Self {
+            hit_count: raw.hit_count,
+            next_cursor_mark: raw.next_cursor_mark,
+            results: raw.result_list.result,
+        }
+    }
+}
+
+/// Parse a Europe PMC `search` JSON response.
+pub fn parse_search_response(json: &str) -> Result<EuropePmcSearchResponse> {
+    Ok(serde_json::from_str(json)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_search_lite() {
+        let json = r#"{
+            "hitCount": 2,
+            "nextCursorMark": "AoJ123",
+            "resultList": {
+                "result": [
+                    {
+                        "id": "33515491",
+                        "source": "MED",
+                        "pmid": "33515491",
+                        "pmcid": "PMC7894017",
+                        "doi": "10.1000/x",
+                        "title": "First",
+                        "authorString": "Smith J.",
+                        "journalTitle": "Nature",
+                        "pubYear": "2021",
+                        "isOpenAccess": "Y"
+                    },
+                    {
+                        "id": "PPR12345",
+                        "source": "PPR",
+                        "title": "A preprint",
+                        "pubYear": "2022"
+                    }
+                ]
+            }
+        }"#;
+
+        let resp = parse_search_response(json).unwrap();
+        assert_eq!(resp.hit_count, 2);
+        assert_eq!(resp.next_cursor_mark.as_deref(), Some("AoJ123"));
+        assert_eq!(resp.results.len(), 2);
+        assert_eq!(resp.results[0].pmcid.as_deref(), Some("PMC7894017"));
+        assert_eq!(resp.results[0].pub_year.as_deref(), Some("2021"));
+        assert_eq!(resp.results[1].source, "PPR");
+    }
+
+    #[test]
+    fn test_parse_search_core_keeps_extra_fields() {
+        let json = r#"{
+            "hitCount": 1,
+            "resultList": {
+                "result": [
+                    {
+                        "id": "1",
+                        "source": "MED",
+                        "title": "Has extra",
+                        "citedByCount": 42,
+                        "inEPMC": "Y"
+                    }
+                ]
+            }
+        }"#;
+
+        let resp = parse_search_response(json).unwrap();
+        let result = &resp.results[0];
+        assert_eq!(
+            result.extra.get("citedByCount").and_then(|v| v.as_i64()),
+            Some(42)
+        );
+        assert_eq!(
+            result.extra.get("inEPMC").and_then(|v| v.as_str()),
+            Some("Y")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_results() {
+        let json = r#"{"hitCount": 0, "resultList": {"result": []}}"#;
+        let resp = parse_search_response(json).unwrap();
+        assert_eq!(resp.hit_count, 0);
+        assert!(resp.results.is_empty());
+        assert!(resp.next_cursor_mark.is_none());
+    }
+}

--- a/pubmed-parser/src/lib.rs
+++ b/pubmed-parser/src/lib.rs
@@ -15,9 +15,15 @@
 
 pub mod common;
 pub mod error;
+pub mod europe_pmc;
 pub mod pmc;
 pub mod pubmed;
 
 // Re-export main types for convenience
 pub use common::{Affiliation, Author, HistoryDate, PmcId, PubMedId, PublicationDate};
 pub use error::{ParseError, Result};
+pub use europe_pmc::{
+    EuropePmcCitation, EuropePmcCitationList, EuropePmcDatabaseLink, EuropePmcDatabaseLinkList,
+    EuropePmcDbCrossReferenceInfo, EuropePmcReference, EuropePmcReferenceList, EuropePmcResult,
+    EuropePmcSearchResponse,
+};


### PR DESCRIPTION
Add support for the Europe PMC RESTful Web Service as a complementary
data source alongside NCBI PubMed/PMC, scoped to the core Rust crates.

pubmed-parser:
- New `europe_pmc` module with lenient JSON response models and pure
  parsers for the search, references, citations, and databaseLinks
  endpoints. Unknown fields are preserved (search `core` results) and
  string-or-number fields (e.g. `pubYear`) are normalized.

pubmed-client:
- New `EuropePmcClient` mirroring `PmcClient`'s construction, sharing
  `ClientConfig`/`RateLimiter`/cache and reusing `RequestExecutor`. It
  uses a dedicated Europe PMC base URL rather than the NCBI `base_url`.
- `EuropePmcId`/`EuropePmcSource` for `(source, id)` addressing.
- Endpoints: cross-source search (cursorMark pagination), JATS full
  text (reusing `parse_pmc_xml`; non-PMC sources can fetch raw XML),
  references/citations (page pagination), database links, and
  supplementary-file download (native only).
- Wired a `europe_pmc` field into the unified `Client` and re-exported
  the new types.

Tests: parser unit tests, wiremock-mocked client tests, and gated
real-API tests (PUBMED_REAL_API_TESTS).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018isdiJ8XXNJACnjcp7j2M3