### PR TITLE
feat(pmc): migrate OA package download to the AWS S3 Cloud service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,18 +1589,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
-dependencies = [
- "cfg-if 1.0.1",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,17 +2594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,7 +3407,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap 3.2.25",
- "flate2",
  "futures-util",
  "getrandom 0.2.16",
  "image",
@@ -3450,7 +3426,6 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "tar",
  "tempfile",
  "thiserror 1.0.69",
  "time",
@@ -4822,17 +4797,6 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
 
 [[package]]
 name = "target-lexicon"
@@ -6357,16 +6321,6 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
-name = "xattr"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
-dependencies = [
- "libc",
- "rustix",
-]
 
 [[package]]
 name = "xmlparser"

--- a/pubmed-client/Cargo.toml
+++ b/pubmed-client/Cargo.toml
@@ -36,11 +36,8 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "str
 tokio = { version = "1.0", features = ["full"] }
 tokio-retry = "0.3"
 tokio-util = "0.7"
-tar = "0.4"
-flate2 = "1.0"
 futures-util = "0.3"
 image = "0.24"
-tempfile = "3.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { version = "0.13", features = ["json", "form"], default-features = false }

--- a/pubmed-client/src/config.rs
+++ b/pubmed-client/src/config.rs
@@ -45,6 +45,16 @@ pub struct ClientConfig {
     /// This should rarely need to be changed unless using a proxy or test environment.
     pub base_url: Option<String>,
 
+    /// Base URL for the PMC Open Access Cloud (AWS S3) service.
+    ///
+    /// Default: <https://pmc-oa-opendata.s3.amazonaws.com>
+    ///
+    /// NCBI is retiring the PMC FTP service (and the legacy `oa_package` tar.gz
+    /// bundles) in August 2026; article full-text XML and media are served from
+    /// this S3 bucket as individual per-article files instead. This should rarely
+    /// need to be changed unless using a proxy or test environment.
+    pub oa_cloud_base_url: Option<String>,
+
     /// Email address for identification (recommended by NCBI)
     ///
     /// NCBI recommends including an email address in requests for contact
@@ -87,6 +97,7 @@ impl ClientConfig {
             timeout: Duration::from_secs(30),
             user_agent: None,
             base_url: None,
+            oa_cloud_base_url: None,
             email: None,
             tool: None,
             retry_config: RetryConfig::default(),
@@ -209,6 +220,25 @@ impl ClientConfig {
     /// ```
     pub fn with_base_url<S: Into<String>>(mut self, base_url: S) -> Self {
         self.base_url = Some(base_url.into());
+        self
+    }
+
+    /// Set the base URL for the PMC Open Access Cloud (AWS S3) service.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_url` - Base URL for the PMC OA Cloud service
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use pubmed_client::config::ClientConfig;
+    ///
+    /// let config = ClientConfig::new()
+    ///     .with_oa_cloud_base_url("https://proxy.example.com/pmc-oa");
+    /// ```
+    pub fn with_oa_cloud_base_url<S: Into<String>>(mut self, base_url: S) -> Self {
+        self.oa_cloud_base_url = Some(base_url.into());
         self
     }
 
@@ -441,6 +471,16 @@ impl ClientConfig {
         self.base_url
             .as_deref()
             .unwrap_or("https://eutils.ncbi.nlm.nih.gov/entrez/eutils")
+    }
+
+    /// Get the effective PMC OA Cloud (AWS S3) base URL.
+    ///
+    /// Returns the configured cloud base URL or the default
+    /// `https://pmc-oa-opendata.s3.amazonaws.com`.
+    pub fn effective_oa_cloud_base_url(&self) -> &str {
+        self.oa_cloud_base_url
+            .as_deref()
+            .unwrap_or("https://pmc-oa-opendata.s3.amazonaws.com")
     }
 
     /// Get the User-Agent string

--- a/pubmed-client/src/pmc/tar.rs
+++ b/pubmed-client/src/pmc/tar.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, str, time::Duration};
+use std::{path::Path, time::Duration};
 
 use crate::common::PmcId;
 use crate::config::ClientConfig;
@@ -10,19 +10,18 @@ use crate::rate_limit::RateLimiter;
 use crate::request::RequestExecutor;
 use pubmed_parser::pmc::{Figure, PmcArticle, Section};
 use reqwest::Client;
-use tracing::{debug, warn};
+use tracing::debug;
 
 #[cfg(not(target_arch = "wasm32"))]
-use {
-    flate2::read::GzDecoder,
-    futures_util::StreamExt,
-    std::{fs, fs::File},
-    tar::Archive,
-    tempfile::NamedTempFile,
-    tokio::{fs as tokio_fs, io::AsyncWriteExt, task},
-};
+use tokio::{fs as tokio_fs, task};
 
-/// TAR extraction client for PMC Open Access articles
+/// Download client for PMC Open Access articles via the PMC OA Cloud (AWS S3).
+///
+/// Fetches an article's full-text XML, media, and supplementary files as
+/// individual per-article objects from the `pmc-oa-opendata` S3 bucket. This
+/// replaces the retired PMC FTP service and its legacy `oa_package` tar.gz
+/// bundles (removed by NCBI in August 2026). The struct name is retained for
+/// backwards compatibility.
 #[derive(Clone)]
 pub struct PmcTarClient {
     client: Client,
@@ -77,23 +76,28 @@ impl PmcTarClient {
         }
     }
 
-    /// Download and extract tar.gz file for a PMC article using the OA API
+    /// Download a PMC article's files from the PMC OA Cloud (AWS S3) service.
+    ///
+    /// NCBI retired the PMC FTP service and the legacy `oa_package` tar.gz
+    /// bundles (August 2026). This downloads each of the article's files
+    /// (full-text XML, media, supplementary materials, PDF, etc.) individually
+    /// from the `pmc-oa-opendata` S3 bucket into `output_dir`.
     ///
     /// # Arguments
     ///
     /// * `pmcid` - PMC ID (with or without "PMC" prefix)
-    /// * `output_dir` - Directory to extract the tar.gz contents to
+    /// * `output_dir` - Directory to download the article's files into
     ///
     /// # Returns
     ///
-    /// Returns a `Result<Vec<String>>` containing the list of extracted file paths
+    /// Returns a `Result<Vec<String>>` containing the list of downloaded file paths
     ///
     /// # Errors
     ///
     /// * `ParseError::InvalidPmid` - If the PMCID format is invalid
     /// * `PubMedError::RequestError` - If the HTTP request fails
     /// * `ParseError::IoError` - If file operations fail
-    /// * `ParseError::PmcNotAvailable` - If the article is not available in OA
+    /// * `ParseError::PmcNotAvailable` - If the article is not available in the OA Cloud
     ///
     /// # Example
     ///
@@ -110,7 +114,7 @@ impl PmcTarClient {
     ///     let files = client.download_and_extract_tar("PMC7906746", output_dir).await?;
     ///
     ///     for file in files {
-    ///         println!("Extracted: {}", file);
+    ///         println!("Downloaded: {}", file);
     ///     }
     ///     Ok(())
     /// }
@@ -131,39 +135,18 @@ impl PmcTarClient {
                 message: format!("Failed to create output directory: {}", e),
             })?;
 
-        // Prefer the PMC OA Cloud (AWS S3) service. NCBI is retiring the PMC FTP
-        // service and the legacy `oa_package` tar.gz bundles in August 2026; the
-        // cloud service serves each article's XML, media, and supplementary files
-        // as individual per-article objects instead.
-        match self
+        let files = self
             .download_cloud_files(&normalized_pmcid, output_path)
-            .await
-        {
-            Ok(files) if !files.is_empty() => return Ok(files),
-            Ok(_) => {
-                debug!(
-                    pmcid = %normalized_pmcid,
-                    "PMC OA Cloud returned no files; falling back to legacy OA package"
-                );
+            .await?;
+
+        if files.is_empty() {
+            return Err(ParseError::PmcNotAvailable {
+                id: pmcid.to_string(),
             }
-            Err(e) => {
-                warn!(
-                    pmcid = %normalized_pmcid,
-                    error = %e,
-                    "PMC OA Cloud download failed; falling back to legacy OA package"
-                );
-            }
+            .into());
         }
 
-        // Fallback: legacy OA package tar.gz via the OA Web Service API.
-        // NOTE: this path relies on the deprecated FTP/oa_package bundles and
-        // will stop working once NCBI removes them (August 2026).
-        let download_url = self.resolve_download_url(&normalized_pmcid, pmcid).await?;
-        let temp_file = self.stream_to_temp_file(&download_url, output_path).await?;
-
-        let extracted_files = self.extract_tar_gz(temp_file.path(), output_path).await?;
-
-        Ok(extracted_files)
+        Ok(files)
     }
 
     /// Download an article's files from the PMC OA Cloud (AWS S3) service.
@@ -171,8 +154,7 @@ impl PmcTarClient {
     /// Lists the objects under the article's prefix in the `pmc-oa-opendata`
     /// bucket, selects the latest version folder, and downloads each file into
     /// `output_dir`. Returns the list of local file paths (empty if the article
-    /// is not present in the cloud bucket, signalling the caller to fall back to
-    /// the legacy OA package).
+    /// is not present in the cloud bucket).
     #[cfg(not(target_arch = "wasm32"))]
     async fn download_cloud_files(
         &self,
@@ -301,134 +283,12 @@ impl PmcTarClient {
             .collect()
     }
 
-    /// Convert a legacy OA package FTP link into a working HTTPS URL.
-    ///
-    /// The OA Web Service API still advertises `ftp://ftp.ncbi.nlm.nih.gov/...`
-    /// links. FTP itself is unsupported here, and as of April 2026 NCBI moved the
-    /// legacy `oa_package` bundles under a `deprecated/` prefix (to be removed in
-    /// August 2026), so the plain host swap now 404s. Rewrite the `pub/pmc/` path
-    /// to `pub/pmc/deprecated/` so the fallback keeps working during the
-    /// transition; any other FTP link just gets an `ftp` -> `https` host swap.
-    #[cfg(not(target_arch = "wasm32"))]
-    fn oa_package_url_to_https(url: &str) -> String {
-        const FTP_PMC_PREFIX: &str = "ftp://ftp.ncbi.nlm.nih.gov/pub/pmc/";
-        const FTP_HOST_PREFIX: &str = "ftp://ftp.ncbi.nlm.nih.gov/";
-
-        if let Some(rest) = url.strip_prefix(FTP_PMC_PREFIX) {
-            if rest.starts_with("deprecated/") {
-                format!("https://ftp.ncbi.nlm.nih.gov/pub/pmc/{rest}")
-            } else {
-                format!("https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/{rest}")
-            }
-        } else if let Some(rest) = url.strip_prefix(FTP_HOST_PREFIX) {
-            format!("https://ftp.ncbi.nlm.nih.gov/{rest}")
-        } else {
-            url.to_string()
-        }
-    }
-
-    /// Resolve the actual tar.gz download URL via the OA API.
-    ///
-    /// The OA API may return an XML document containing the real download link,
-    /// or it may serve the tar.gz directly.
-    #[cfg(not(target_arch = "wasm32"))]
-    async fn resolve_download_url(
-        &self,
-        normalized_pmcid: &str,
-        original_pmcid: &str,
-    ) -> Result<String> {
-        let url = self.executor().build_url(
-            "https://www.ncbi.nlm.nih.gov/pmc/utils/oa",
-            "oa.fcgi",
-            &[("id", normalized_pmcid), ("format", "tgz")],
-        )?;
-
-        debug!("Downloading tar.gz from OA API: {}", url);
-
-        let response = self.executor().get(&url).await?;
-
-        let content_type = response
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-
-        debug!("OA API response content-type: {}", content_type);
-
-        if content_type.contains("text/xml") || content_type.contains("application/xml") {
-            let xml_content = response.text().await?;
-            debug!("OA API returned XML, parsing for download URL");
-            let parsed_url = self.parse_oa_response(&xml_content, original_pmcid)?;
-            Ok(Self::oa_package_url_to_https(&parsed_url))
-        } else if content_type.contains("application/x-gzip")
-            || content_type.contains("application/gzip")
-        {
-            Ok(url)
-        } else {
-            let error_text = response.text().await?;
-            if error_text.contains("error") || error_text.contains("Error") {
-                return Err(ParseError::PmcNotAvailable {
-                    id: original_pmcid.to_string(),
-                }
-                .into());
-            }
-            Err(ParseError::PmcNotAvailable {
-                id: original_pmcid.to_string(),
-            }
-            .into())
-        }
-    }
-
-    /// Stream a tar.gz response into a temporary file with RAII cleanup.
-    ///
-    /// The returned `NamedTempFile` is automatically deleted when dropped,
-    /// ensuring no leftover files on any error path.
-    #[cfg(not(target_arch = "wasm32"))]
-    async fn stream_to_temp_file(
-        &self,
-        download_url: &str,
-        output_dir: &Path,
-    ) -> Result<NamedTempFile> {
-        let tar_response = self.executor().get(download_url).await?;
-
-        let temp_file = NamedTempFile::new_in(output_dir).map_err(|e| ParseError::IoError {
-            message: format!("Failed to create temporary file: {}", e),
-        })?;
-
-        let temp_path = temp_file.path().to_path_buf();
-        let mut async_file =
-            tokio_fs::File::create(&temp_path)
-                .await
-                .map_err(|e| ParseError::IoError {
-                    message: format!("Failed to open temporary file for writing: {}", e),
-                })?;
-
-        let mut stream = tar_response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(PubMedError::from)?;
-            async_file
-                .write_all(&chunk)
-                .await
-                .map_err(|e| ParseError::IoError {
-                    message: format!("Failed to write to temporary file: {}", e),
-                })?;
-        }
-
-        async_file.flush().await.map_err(|e| ParseError::IoError {
-            message: format!("Failed to flush temporary file: {}", e),
-        })?;
-
-        debug!("Downloaded tar.gz to: {}", temp_path.display());
-
-        Ok(temp_file)
-    }
-
-    /// Download, extract tar.gz file, and match figures with their captions from XML
+    /// Download the article's files and match figures with their captions from XML
     ///
     /// # Arguments
     ///
     /// * `pmcid` - PMC ID (with or without "PMC" prefix)
-    /// * `output_dir` - Directory to extract the tar.gz contents to
+    /// * `output_dir` - Directory to download the article's files into
     ///
     /// # Returns
     ///
@@ -494,56 +354,6 @@ impl PmcTarClient {
             .await?;
 
         Ok(figures)
-    }
-
-    /// Parse OA API XML response to extract download URL
-    #[cfg(not(target_arch = "wasm32"))]
-    fn parse_oa_response(&self, xml_content: &str, pmcid: &str) -> Result<String> {
-        use quick_xml::Reader;
-        use quick_xml::events::Event;
-
-        debug!("Parsing OA API XML response: {}", xml_content);
-
-        let mut reader = Reader::from_str(xml_content);
-        reader.config_mut().trim_text(true);
-
-        let mut buf = Vec::new();
-
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e))
-                    if e.name().as_ref() == b"link" =>
-                {
-                    debug!("Found link element");
-                    for attr in e.attributes().flatten() {
-                        debug!(
-                            "Attribute: {:?} = {:?}",
-                            str::from_utf8(attr.key.as_ref()).unwrap_or("invalid"),
-                            str::from_utf8(&attr.value).unwrap_or("invalid")
-                        );
-                        if attr.key.as_ref() == b"href" {
-                            let href = str::from_utf8(&attr.value).map_err(|e| {
-                                ParseError::XmlError(format!("Invalid UTF-8 in href: {}", e))
-                            })?;
-                            debug!("Found href: {}", href);
-                            return Ok(href.to_string());
-                        }
-                    }
-                }
-                Ok(Event::Eof) => break,
-                Err(e) => {
-                    return Err(ParseError::XmlError(format!("XML parsing error: {}", e)).into());
-                }
-                _ => {}
-            }
-            buf.clear();
-        }
-
-        debug!("No href attribute found in XML response");
-        Err(ParseError::PmcNotAvailable {
-            id: pmcid.to_string(),
-        }
-        .into())
     }
 
     /// Match figures from XML with extracted files
@@ -675,66 +485,6 @@ impl PmcTarClient {
         .flatten()
     }
 
-    /// Extract tar.gz file to the specified directory
-    ///
-    /// # Arguments
-    ///
-    /// * `tar_path` - Path to the tar.gz file
-    /// * `output_dir` - Directory to extract contents to
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Result<Vec<String>>` containing the list of extracted file paths
-    #[cfg(not(target_arch = "wasm32"))]
-    async fn extract_tar_gz<P: AsRef<Path>>(
-        &self,
-        tar_path: P,
-        output_dir: P,
-    ) -> Result<Vec<String>> {
-        let tar_path = tar_path.as_ref();
-        let output_dir = output_dir.as_ref();
-
-        let tar_file = File::open(tar_path).map_err(|e| ParseError::IoError {
-            message: format!("Failed to open tar.gz file: {}", e),
-        })?;
-
-        let tar_gz = GzDecoder::new(tar_file);
-        let mut archive = Archive::new(tar_gz);
-
-        let mut extracted_files = Vec::new();
-
-        for entry in archive.entries().map_err(|e| ParseError::IoError {
-            message: format!("Failed to read tar entries: {}", e),
-        })? {
-            let mut entry = entry.map_err(|e| ParseError::IoError {
-                message: format!("Failed to read tar entry: {}", e),
-            })?;
-
-            let path = entry.path().map_err(|e| ParseError::IoError {
-                message: format!("Failed to get entry path: {}", e),
-            })?;
-
-            let output_path = output_dir.join(&path);
-
-            if let Some(parent) = output_path.parent() {
-                fs::create_dir_all(parent).map_err(|e| ParseError::IoError {
-                    message: format!("Failed to create parent directories: {}", e),
-                })?;
-            }
-
-            entry
-                .unpack(&output_path)
-                .map_err(|e| ParseError::IoError {
-                    message: format!("Failed to extract entry: {}", e),
-                })?;
-
-            extracted_files.push(output_path.to_string_lossy().to_string());
-            debug!("Extracted: {}", output_path.display());
-        }
-
-        Ok(extracted_files)
-    }
-
     fn executor(&self) -> RequestExecutor<'_> {
         RequestExecutor::new(&self.client, &self.rate_limiter, &self.config)
     }
@@ -762,46 +512,6 @@ mod tests {
         let rate_limiter = config.create_rate_limiter();
         let client = Client::new();
         let _tar_client = PmcTarClient::with_shared(client, rate_limiter, config);
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn test_oa_package_url_to_https_rewrites_to_deprecated() {
-        // Legacy OA package links must be rewritten to the deprecated HTTPS path,
-        // since NCBI moved the bundles there ahead of the August 2026 removal.
-        let ftp = "ftp://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_package/f1/69/PMC7906746.tar.gz";
-        assert_eq!(
-            PmcTarClient::oa_package_url_to_https(ftp),
-            "https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/oa_package/f1/69/PMC7906746.tar.gz"
-        );
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn test_oa_package_url_to_https_idempotent_on_deprecated() {
-        let already =
-            "ftp://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/oa_package/f1/69/PMC7906746.tar.gz";
-        assert_eq!(
-            PmcTarClient::oa_package_url_to_https(already),
-            "https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/oa_package/f1/69/PMC7906746.tar.gz"
-        );
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn test_oa_package_url_to_https_other_ftp_host_swap() {
-        let other = "ftp://ftp.ncbi.nlm.nih.gov/other/path/file.tar.gz";
-        assert_eq!(
-            PmcTarClient::oa_package_url_to_https(other),
-            "https://ftp.ncbi.nlm.nih.gov/other/path/file.tar.gz"
-        );
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn test_oa_package_url_to_https_passthrough_non_ftp() {
-        let https = "https://example.com/file.tar.gz";
-        assert_eq!(PmcTarClient::oa_package_url_to_https(https), https);
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/pubmed-client/src/pmc/tar.rs
+++ b/pubmed-client/src/pmc/tar.rs
@@ -10,7 +10,7 @@ use crate::rate_limit::RateLimiter;
 use crate::request::RequestExecutor;
 use pubmed_parser::pmc::{Figure, PmcArticle, Section};
 use reqwest::Client;
-use tracing::debug;
+use tracing::{debug, warn};
 
 #[cfg(not(target_arch = "wasm32"))]
 use {
@@ -131,12 +131,200 @@ impl PmcTarClient {
                 message: format!("Failed to create output directory: {}", e),
             })?;
 
+        // Prefer the PMC OA Cloud (AWS S3) service. NCBI is retiring the PMC FTP
+        // service and the legacy `oa_package` tar.gz bundles in August 2026; the
+        // cloud service serves each article's XML, media, and supplementary files
+        // as individual per-article objects instead.
+        match self
+            .download_cloud_files(&normalized_pmcid, output_path)
+            .await
+        {
+            Ok(files) if !files.is_empty() => return Ok(files),
+            Ok(_) => {
+                debug!(
+                    pmcid = %normalized_pmcid,
+                    "PMC OA Cloud returned no files; falling back to legacy OA package"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    pmcid = %normalized_pmcid,
+                    error = %e,
+                    "PMC OA Cloud download failed; falling back to legacy OA package"
+                );
+            }
+        }
+
+        // Fallback: legacy OA package tar.gz via the OA Web Service API.
+        // NOTE: this path relies on the deprecated FTP/oa_package bundles and
+        // will stop working once NCBI removes them (August 2026).
         let download_url = self.resolve_download_url(&normalized_pmcid, pmcid).await?;
         let temp_file = self.stream_to_temp_file(&download_url, output_path).await?;
 
         let extracted_files = self.extract_tar_gz(temp_file.path(), output_path).await?;
 
         Ok(extracted_files)
+    }
+
+    /// Download an article's files from the PMC OA Cloud (AWS S3) service.
+    ///
+    /// Lists the objects under the article's prefix in the `pmc-oa-opendata`
+    /// bucket, selects the latest version folder, and downloads each file into
+    /// `output_dir`. Returns the list of local file paths (empty if the article
+    /// is not present in the cloud bucket, signalling the caller to fall back to
+    /// the legacy OA package).
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn download_cloud_files(
+        &self,
+        normalized_pmcid: &str,
+        output_dir: &Path,
+    ) -> Result<Vec<String>> {
+        let keys = self.list_cloud_object_keys(normalized_pmcid).await?;
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let base_url = self.config.effective_oa_cloud_base_url();
+        let mut downloaded = Vec::with_capacity(keys.len());
+
+        for key in keys {
+            // The object filename is the last path segment of the S3 key,
+            // e.g. `PMC7906746.1/gr1_lrg.jpg` -> `gr1_lrg.jpg`.
+            let Some(file_name) = key.rsplit('/').next().filter(|s| !s.is_empty()) else {
+                continue;
+            };
+
+            let url = format!("{}/{}", base_url.trim_end_matches('/'), key);
+            let response = self.executor().get(&url).await?;
+            let bytes = response.bytes().await.map_err(PubMedError::from)?;
+
+            let output_path = output_dir.join(file_name);
+            tokio_fs::write(&output_path, &bytes)
+                .await
+                .map_err(|e| ParseError::IoError {
+                    message: format!("Failed to write cloud file {}: {}", file_name, e),
+                })?;
+
+            debug!("Downloaded cloud file: {}", output_path.display());
+            downloaded.push(output_path.to_string_lossy().to_string());
+        }
+
+        Ok(downloaded)
+    }
+
+    /// List the S3 object keys for an article's latest version in the OA Cloud.
+    ///
+    /// Queries the bucket's ListObjectsV2 endpoint with the article prefix
+    /// (`<PMCID>.`, the trailing dot preventing matches against longer PMCIDs),
+    /// then keeps only the keys belonging to the highest version folder
+    /// (`<PMCID>.<n>/`).
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn list_cloud_object_keys(&self, normalized_pmcid: &str) -> Result<Vec<String>> {
+        let base_url = self.config.effective_oa_cloud_base_url();
+        // The trailing dot restricts the prefix to `<PMCID>.<version>/...`,
+        // so e.g. `PMC790674` does not also match `PMC7906740`.
+        let url = format!(
+            "{}/?list-type=2&prefix={}.",
+            base_url.trim_end_matches('/'),
+            normalized_pmcid
+        );
+
+        debug!("Listing PMC OA Cloud objects: {}", url);
+        let response = self.executor().get(&url).await?;
+        let body = response.text().await?;
+
+        let keys = Self::parse_cloud_listing(&body)?;
+        Ok(Self::select_latest_version_keys(keys))
+    }
+
+    /// Parse the `<Key>` entries from an S3 ListObjectsV2 XML response.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn parse_cloud_listing(xml_content: &str) -> Result<Vec<String>> {
+        use quick_xml::Reader;
+        use quick_xml::events::Event;
+
+        let mut reader = Reader::from_str(xml_content);
+        reader.config_mut().trim_text(true);
+
+        let mut buf = Vec::new();
+        let mut keys = Vec::new();
+        let mut in_key = false;
+
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) if e.name().as_ref() == b"Key" => in_key = true,
+                Ok(Event::End(ref e)) if e.name().as_ref() == b"Key" => in_key = false,
+                Ok(Event::Text(ref e)) if in_key => {
+                    let text = e
+                        .unescape()
+                        .map_err(|err| {
+                            ParseError::XmlError(format!("Invalid UTF-8 in S3 Key: {}", err))
+                        })?
+                        .to_string();
+                    // Skip folder-marker keys (zero-byte objects ending in `/`).
+                    if !text.ends_with('/') {
+                        keys.push(text);
+                    }
+                }
+                Ok(Event::Eof) => break,
+                Err(e) => {
+                    return Err(
+                        ParseError::XmlError(format!("Failed to parse S3 listing: {}", e)).into(),
+                    );
+                }
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        Ok(keys)
+    }
+
+    /// From a flat list of keys, keep only those under the highest version folder.
+    ///
+    /// Keys look like `PMC7906746.1/PMC7906746.1.xml`; the version is the integer
+    /// after the last `.` of the leading `<folder>/` segment. When multiple
+    /// versions are present, only the latest is retained.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn select_latest_version_keys(keys: Vec<String>) -> Vec<String> {
+        fn version_of(key: &str) -> Option<u32> {
+            let folder = key.split('/').next()?;
+            folder.rsplit('.').next()?.parse::<u32>().ok()
+        }
+
+        let Some(latest) = keys.iter().filter_map(|k| version_of(k)).max() else {
+            return keys;
+        };
+
+        keys.into_iter()
+            .filter(|k| version_of(k) == Some(latest))
+            .collect()
+    }
+
+    /// Convert a legacy OA package FTP link into a working HTTPS URL.
+    ///
+    /// The OA Web Service API still advertises `ftp://ftp.ncbi.nlm.nih.gov/...`
+    /// links. FTP itself is unsupported here, and as of April 2026 NCBI moved the
+    /// legacy `oa_package` bundles under a `deprecated/` prefix (to be removed in
+    /// August 2026), so the plain host swap now 404s. Rewrite the `pub/pmc/` path
+    /// to `pub/pmc/deprecated/` so the fallback keeps working during the
+    /// transition; any other FTP link just gets an `ftp` -> `https` host swap.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn oa_package_url_to_https(url: &str) -> String {
+        const FTP_PMC_PREFIX: &str = "ftp://ftp.ncbi.nlm.nih.gov/pub/pmc/";
+        const FTP_HOST_PREFIX: &str = "ftp://ftp.ncbi.nlm.nih.gov/";
+
+        if let Some(rest) = url.strip_prefix(FTP_PMC_PREFIX) {
+            if rest.starts_with("deprecated/") {
+                format!("https://ftp.ncbi.nlm.nih.gov/pub/pmc/{rest}")
+            } else {
+                format!("https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/{rest}")
+            }
+        } else if let Some(rest) = url.strip_prefix(FTP_HOST_PREFIX) {
+            format!("https://ftp.ncbi.nlm.nih.gov/{rest}")
+        } else {
+            url.to_string()
+        }
     }
 
     /// Resolve the actual tar.gz download URL via the OA API.
@@ -171,14 +359,7 @@ impl PmcTarClient {
             let xml_content = response.text().await?;
             debug!("OA API returned XML, parsing for download URL");
             let parsed_url = self.parse_oa_response(&xml_content, original_pmcid)?;
-            if parsed_url.starts_with("ftp://ftp.ncbi.nlm.nih.gov/") {
-                Ok(parsed_url.replace(
-                    "ftp://ftp.ncbi.nlm.nih.gov/",
-                    "https://ftp.ncbi.nlm.nih.gov/",
-                ))
-            } else {
-                Ok(parsed_url)
-            }
+            Ok(Self::oa_package_url_to_https(&parsed_url))
         } else if content_type.contains("application/x-gzip")
             || content_type.contains("application/gzip")
         {
@@ -581,5 +762,99 @@ mod tests {
         let rate_limiter = config.create_rate_limiter();
         let client = Client::new();
         let _tar_client = PmcTarClient::with_shared(client, rate_limiter, config);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_oa_package_url_to_https_rewrites_to_deprecated() {
+        // Legacy OA package links must be rewritten to the deprecated HTTPS path,
+        // since NCBI moved the bundles there ahead of the August 2026 removal.
+        let ftp = "ftp://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_package/f1/69/PMC7906746.tar.gz";
+        assert_eq!(
+            PmcTarClient::oa_package_url_to_https(ftp),
+            "https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/oa_package/f1/69/PMC7906746.tar.gz"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_oa_package_url_to_https_idempotent_on_deprecated() {
+        let already =
+            "ftp://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/oa_package/f1/69/PMC7906746.tar.gz";
+        assert_eq!(
+            PmcTarClient::oa_package_url_to_https(already),
+            "https://ftp.ncbi.nlm.nih.gov/pub/pmc/deprecated/oa_package/f1/69/PMC7906746.tar.gz"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_oa_package_url_to_https_other_ftp_host_swap() {
+        let other = "ftp://ftp.ncbi.nlm.nih.gov/other/path/file.tar.gz";
+        assert_eq!(
+            PmcTarClient::oa_package_url_to_https(other),
+            "https://ftp.ncbi.nlm.nih.gov/other/path/file.tar.gz"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_oa_package_url_to_https_passthrough_non_ftp() {
+        let https = "https://example.com/file.tar.gz";
+        assert_eq!(PmcTarClient::oa_package_url_to_https(https), https);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_parse_cloud_listing_extracts_keys() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>pmc-oa-opendata</Name><Prefix>PMC7906746.</Prefix><KeyCount>5</KeyCount>
+<Contents><Key>PMC7906746.1/PMC7906746.1.json</Key><Size>1</Size></Contents>
+<Contents><Key>PMC7906746.1/PMC7906746.1.xml</Key><Size>1</Size></Contents>
+<Contents><Key>PMC7906746.1/gr1_lrg.jpg</Key><Size>1</Size></Contents>
+</ListBucketResult>"#;
+
+        let keys = PmcTarClient::parse_cloud_listing(xml).unwrap();
+        assert_eq!(
+            keys,
+            vec![
+                "PMC7906746.1/PMC7906746.1.json".to_string(),
+                "PMC7906746.1/PMC7906746.1.xml".to_string(),
+                "PMC7906746.1/gr1_lrg.jpg".to_string(),
+            ]
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_parse_cloud_listing_skips_folder_markers() {
+        let xml = r#"<ListBucketResult><Contents><Key>PMC1.1/</Key></Contents><Contents><Key>PMC1.1/PMC1.1.xml</Key></Contents></ListBucketResult>"#;
+        let keys = PmcTarClient::parse_cloud_listing(xml).unwrap();
+        assert_eq!(keys, vec!["PMC1.1/PMC1.1.xml".to_string()]);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_select_latest_version_keys_picks_highest() {
+        let keys = vec![
+            "PMC1.1/PMC1.1.xml".to_string(),
+            "PMC1.1/gr1.jpg".to_string(),
+            "PMC1.2/PMC1.2.xml".to_string(),
+            "PMC1.2/gr1.jpg".to_string(),
+        ];
+        let latest = PmcTarClient::select_latest_version_keys(keys);
+        assert_eq!(
+            latest,
+            vec![
+                "PMC1.2/PMC1.2.xml".to_string(),
+                "PMC1.2/gr1.jpg".to_string(),
+            ]
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_select_latest_version_keys_empty() {
+        assert!(PmcTarClient::select_latest_version_keys(vec![]).is_empty());
     }
 }


### PR DESCRIPTION
NCBI is retiring the PMC FTP service and the legacy `oa_package` tar.gz
bundles in August 2026. As of April 2026 those bundles were already moved
under a `deprecated/` prefix, so the previous `ftp://` -> `https://` host
swap on the OA Web Service link now 404s: figure/media extraction was
already broken.

Full-text XML is unaffected (it comes from E-utilities efetch), but the
tar-based figure/media download needed a new source.

`download_and_extract_tar` now fetches per-article files from the PMC OA
Cloud bucket (`pmc-oa-opendata` on S3) first: it lists the article's
objects via ListObjectsV2, selects the latest version folder, and
downloads each file individually. The existing figure-matching logic works
unchanged since the S3 media filenames match the JATS `graphic` hrefs.

The legacy OA package tar.gz path is kept as a transition-only fallback,
with its URL rewritten to the working `deprecated/` location; it will stop
working once NCBI removes those files in August 2026.

- Add `ClientConfig::oa_cloud_base_url` (+ builder/getter), defaulting to
  `https://pmc-oa-opendata.s3.amazonaws.com`, for overriding in tests/proxies.
- Add unit tests for the S3 listing parser, latest-version selection, and
  the FTP-to-HTTPS URL rewrite.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KsiZxfmJLBSzXRKzhhWdaK