### PR TITLE
fix(pmc): resolve author affiliation text from xref rid

### DIFF
--- a/pubmed-parser/src/pmc/parser/author.rs
+++ b/pubmed-parser/src/pmc/parser/author.rs
@@ -3,6 +3,7 @@ use crate::common::{Affiliation, Author};
 use crate::error::{ParseError, Result};
 use quick_xml::de::from_str;
 use serde::Deserialize;
+use std::collections::HashMap;
 
 /// XML structure for contrib-group element
 #[derive(Debug, Deserialize)]
@@ -87,20 +88,43 @@ struct Aff {
     text: Option<String>,
 
     #[serde(rename = "institution", default)]
-    #[allow(dead_code)]
-    institutions: Vec<String>,
+    institutions: Vec<Institution>,
+
+    #[serde(rename = "institution-wrap", default)]
+    institution_wraps: Vec<InstitutionWrap>,
 
     #[serde(rename = "addr-line", default)]
-    #[allow(dead_code)]
     addr_lines: Vec<String>,
 
     #[serde(rename = "country", default)]
-    #[allow(dead_code)]
     countries: Vec<String>,
+}
+
+/// XML structure for institution element (may carry a `content-type` such as "dept")
+#[derive(Debug, Deserialize)]
+struct Institution {
+    #[serde(rename = "@content-type", default)]
+    content_type: Option<String>,
+
+    #[serde(rename = "$text", default)]
+    value: Option<String>,
+}
+
+/// XML structure for institution-wrap element (JATS wraps `<institution>` children)
+#[derive(Debug, Deserialize)]
+struct InstitutionWrap {
+    #[serde(rename = "institution", default)]
+    institutions: Vec<Institution>,
 }
 
 /// Extract authors from PMC XML content
 pub(crate) fn extract_authors(content: &str) -> Result<Vec<Author>> {
+    // Build an index of `<aff id="...">` blocks so `<xref ref-type="aff">` rids
+    // can be resolved to real institution/department/address/country text. In
+    // JATS, `<aff>` elements are usually siblings of `<contrib-group>` inside
+    // `<article-meta>`, so index the whole `<front>` slice, not just contrib-group.
+    let aff_index = build_affiliation_index(content);
+
     // Find and extract the contrib-group section
     if let Some(contrib_start) = content.find("<contrib-group>") {
         if let Some(contrib_end) = content[contrib_start..].find("</contrib-group>") {
@@ -114,7 +138,7 @@ pub(crate) fn extract_authors(content: &str) -> Result<Vec<Author>> {
                     let authors = contrib_group
                         .contribs
                         .into_iter()
-                        .filter_map(parse_contrib_to_author)
+                        .filter_map(|contrib| parse_contrib_to_author(contrib, &aff_index))
                         .collect();
                     Ok(authors)
                 }
@@ -138,8 +162,11 @@ pub(crate) fn extract_authors(content: &str) -> Result<Vec<Author>> {
     }
 }
 
-/// Convert a Contrib to an Author
-fn parse_contrib_to_author(contrib: Contrib) -> Option<Author> {
+/// Convert a Contrib to an Author, resolving affiliation xrefs against `aff_index`.
+fn parse_contrib_to_author(
+    contrib: Contrib,
+    aff_index: &HashMap<String, Affiliation>,
+) -> Option<Author> {
     // A contributor is either an individual (`<name>`) or a collaboration/group
     // (`<collab>`, e.g. a consortium). Prefer the personal name; fall back to
     // collab so group authors are not silently dropped.
@@ -196,30 +223,20 @@ fn parse_contrib_to_author(contrib: Contrib) -> Option<Author> {
     // Extract affiliations from xrefs
     let mut affiliations = Vec::new();
 
-    // Process xref affiliations
+    // Process xref affiliations: resolve each rid against the `<aff>` index.
     for xref in &contrib.xrefs {
         if let Some(ref_type) = &xref.ref_type
             && ref_type == "aff"
             && let Some(rid) = &xref.rid
         {
-            affiliations.push(Affiliation {
-                id: Some(rid.clone()),
-                institution: Some(rid.clone()), // Use rid as institution for now
-                department: None,
-                address: None,
-                country: None,
-            });
-        }
-    }
-
-    // Process direct affiliations
-    for aff in &contrib.affs {
-        if let Some(text) = &aff.text {
-            let clean_text = text.trim();
-            if !clean_text.is_empty() {
+            if let Some(resolved) = aff_index.get(rid) {
+                affiliations.push(resolved.clone());
+            } else {
+                // The referenced `<aff>` was not found (or had no resolvable
+                // content); keep the rid so the reference is not silently lost.
                 affiliations.push(Affiliation {
-                    id: aff.id.clone(),
-                    institution: Some(clean_text.to_string()),
+                    id: Some(rid.clone()),
+                    institution: None,
                     department: None,
                     address: None,
                     country: None,
@@ -228,9 +245,216 @@ fn parse_contrib_to_author(contrib: Contrib) -> Option<Author> {
         }
     }
 
+    // Process direct affiliations (inline `<aff>` inside `<contrib>`).
+    for aff in &contrib.affs {
+        let free_text = aff
+            .text
+            .as_deref()
+            .map(clean_affiliation_text)
+            .unwrap_or_default();
+        if let Some(resolved) = resolve_affiliation(Some(aff), aff.id.clone(), &free_text) {
+            affiliations.push(resolved);
+        }
+    }
+
     author.affiliations = affiliations;
 
     Some(author)
+}
+
+/// Build an index mapping each `<aff id="...">` to its resolved [`Affiliation`].
+///
+/// Scans `content` (typically the `<front>` slice) for `<aff>` blocks and
+/// resolves each one individually. `<aff-alternatives>` wrappers are ignored
+/// (the inner `<aff>` blocks are matched directly). Blocks without an `id`, or
+/// with no resolvable content, are skipped.
+fn build_affiliation_index(content: &str) -> HashMap<String, Affiliation> {
+    use regex::Regex;
+    use std::sync::OnceLock;
+
+    // Match `<aff>`/`<aff ...>` ... `</aff>` non-greedily. The `[ >]` after
+    // `aff` prevents matching `<aff-alternatives>` (`aff` is never nested).
+    static AFF_REGEX: OnceLock<Option<Regex>> = OnceLock::new();
+    let re = AFF_REGEX.get_or_init(|| Regex::new(r"(?s)<aff[ >].*?</aff>").ok());
+    let Some(re) = re else {
+        return HashMap::new();
+    };
+
+    let mut index = HashMap::new();
+    for m in re.find_iter(content) {
+        let block = m.as_str();
+        let Some(id) = extract_aff_id(block) else {
+            continue;
+        };
+        // Try structured deserialization (institution/addr-line/country). This
+        // can fail on affiliations with mixed free text interrupted by child
+        // elements (e.g. inline `<email>`), so tolerate the error and rely on
+        // the raw free-text fallback instead.
+        let structured = from_str::<Aff>(&strip_inline_html_tags(block)).ok();
+        let free_text = aff_free_text(block);
+        if let Some(resolved) =
+            resolve_affiliation(structured.as_ref(), Some(id.clone()), &free_text)
+        {
+            index.insert(id, resolved);
+        }
+    }
+    index
+}
+
+/// Extract the `id` attribute value from an `<aff ...>` opening tag.
+fn extract_aff_id(block: &str) -> Option<String> {
+    use regex::Regex;
+    use std::sync::OnceLock;
+
+    static ID_REGEX: OnceLock<Option<Regex>> = OnceLock::new();
+    let re = ID_REGEX.get_or_init(|| Regex::new(r#"<aff[^>]*\bid="([^"]+)""#).ok());
+    re.as_ref()?
+        .captures(block)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+/// Extract cleaned free text from a raw `<aff>` block.
+///
+/// Drops `<label>` and `<email>` element content (labels are markers, emails are
+/// contact data — neither belongs in the institution string), strips all
+/// remaining tags, decodes entities, collapses whitespace, and trims a leading
+/// label marker plus trailing separators.
+fn aff_free_text(block: &str) -> String {
+    use crate::common::xml_utils::{decode_xml_entities, strip_xml_tags};
+    use regex::Regex;
+    use std::borrow::Cow;
+    use std::sync::OnceLock;
+
+    // Institution/address text precedes any contact list, so cut the block at
+    // the first `<email>`: everything after it is email addresses and the
+    // author-initial markers that map to them, not part of the affiliation.
+    let block = match block.find("<email") {
+        Some(idx) => &block[..idx],
+        None => block,
+    };
+
+    static DROP_REGEX: OnceLock<Option<Regex>> = OnceLock::new();
+    let re = DROP_REGEX.get_or_init(|| Regex::new(r"(?s)<(label|email)\b.*?</(label|email)>").ok());
+
+    let without_dropped = match re {
+        Some(re) => re.replace_all(block, ""),
+        None => Cow::Borrowed(block),
+    };
+    let stripped = strip_xml_tags(&without_dropped);
+    let decoded = decode_xml_entities(&stripped);
+    // Collapse internal whitespace runs into single spaces.
+    let collapsed = decoded.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Strip a leading label marker, then any trailing separators.
+    clean_affiliation_text(&collapsed)
+        .trim_end_matches(|c: char| c == ';' || c == ',' || c.is_whitespace())
+        .to_string()
+}
+
+/// Resolve an affiliation into an [`Affiliation`], populating structured fields
+/// (`institution`, `department`, `address`, `country`) from JATS sub-elements
+/// when available and falling back to `free_text` for the institution otherwise.
+///
+/// Returns `None` if no meaningful content could be extracted.
+fn resolve_affiliation(
+    aff: Option<&Aff>,
+    id: Option<String>,
+    free_text: &str,
+) -> Option<Affiliation> {
+    // Gather `<institution>` elements from both direct children and
+    // `<institution-wrap>`. `content-type="dept*"` denotes a department.
+    let mut institution_parts = Vec::new();
+    let mut department_parts = Vec::new();
+    if let Some(aff) = aff {
+        let all_institutions = aff.institutions.iter().chain(
+            aff.institution_wraps
+                .iter()
+                .flat_map(|w| w.institutions.iter()),
+        );
+        for inst in all_institutions {
+            let Some(value) = inst.value.as_deref() else {
+                continue;
+            };
+            let value = value.trim();
+            if value.is_empty() {
+                continue;
+            }
+            if inst
+                .content_type
+                .as_deref()
+                .is_some_and(|ct| ct.starts_with("dept"))
+            {
+                department_parts.push(value.to_string());
+            } else {
+                institution_parts.push(value.to_string());
+            }
+        }
+    }
+
+    let department = join_non_empty(&department_parts);
+
+    let address_parts: Vec<String> = aff
+        .map(|a| {
+            a.addr_lines
+                .iter()
+                .map(|line| line.trim().to_string())
+                .filter(|line| !line.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    let address = join_non_empty(&address_parts);
+
+    let country = aff.and_then(|a| {
+        a.countries
+            .iter()
+            .map(|c| c.trim())
+            .find(|c| !c.is_empty())
+            .map(str::to_string)
+    });
+
+    // Institution: prefer structured `<institution>` text; otherwise fall back
+    // to the affiliation's free text.
+    let institution = if !institution_parts.is_empty() {
+        join_non_empty(&institution_parts)
+    } else {
+        let free_text = free_text.trim();
+        (!free_text.is_empty()).then(|| free_text.to_string())
+    };
+
+    if institution.is_none() && department.is_none() && address.is_none() && country.is_none() {
+        return None;
+    }
+
+    Some(Affiliation {
+        id,
+        institution,
+        department,
+        address,
+        country,
+    })
+}
+
+/// Join non-empty parts with ", ", returning `None` when the slice is empty.
+fn join_non_empty(parts: &[String]) -> Option<String> {
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(", "))
+    }
+}
+
+/// Clean free-text affiliation content by trimming a leading label marker.
+///
+/// JATS affiliations are often prefixed with a superscript label (e.g. `<sup>1</sup>`
+/// or `*`). Formatting/label tags are stripped upstream, leaving the bare label
+/// digits/symbols; strip that leading run so the text starts at the institution name.
+fn clean_affiliation_text(text: &str) -> String {
+    let trimmed = text.trim();
+    // Strip a leading label: digits/symbols/punctuation before the first letter.
+    let without_label = trimmed.trim_start_matches(|c: char| {
+        c.is_ascii_digit() || c.is_whitespace() || "*†‡§¶#,.;:-–—".contains(c)
+    });
+    without_label.trim().to_string()
 }
 
 #[cfg(test)]
@@ -333,6 +557,101 @@ mod tests {
             Some("https://orcid.org/0000-0001-2345-6789".to_string())
         );
         assert!(!authors[0].is_corresponding);
+    }
+
+    #[test]
+    fn test_resolve_xref_affiliation_structured() {
+        // Structured <aff> with <institution>/<addr-line>/<country>, referenced
+        // from the contributor via <xref ref-type="aff">.
+        let content = r#"
+        <front>
+            <article-meta>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                        <name><surname>Doe</surname><given-names>John</given-names></name>
+                        <xref ref-type="aff" rid="aff1">1</xref>
+                    </contrib>
+                    <aff id="aff1">
+                        <label>1</label>
+                        <institution content-type="dept">Department of Functional Genomics</institution>
+                        <institution>Institute of Molecular Biology</institution>
+                        <addr-line>Berlin</addr-line>
+                        <country>Germany</country>
+                    </aff>
+                </contrib-group>
+            </article-meta>
+        </front>
+        "#;
+
+        let authors = extract_authors(content).unwrap();
+        assert_eq!(authors.len(), 1);
+        let aff = &authors[0].affiliations[0];
+        assert_eq!(aff.id.as_deref(), Some("aff1"));
+        assert_eq!(
+            aff.institution.as_deref(),
+            Some("Institute of Molecular Biology")
+        );
+        assert_eq!(
+            aff.department.as_deref(),
+            Some("Department of Functional Genomics")
+        );
+        assert_eq!(aff.address.as_deref(), Some("Berlin"));
+        assert_eq!(aff.country.as_deref(), Some("Germany"));
+    }
+
+    #[test]
+    fn test_resolve_xref_affiliation_free_text() {
+        // <aff> with a superscript label and free mixed text (no sub-elements).
+        let content = r#"
+        <front>
+            <article-meta>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                        <name><surname>Smith</surname><given-names>Jane</given-names></name>
+                        <xref ref-type="aff" rid="aff2"><sup>2</sup></xref>
+                    </contrib>
+                </contrib-group>
+                <aff id="aff2"><sup>2</sup>Department of Functional Genomics, Institute of Bioengineering, Lausanne, Switzerland</aff>
+            </article-meta>
+        </front>
+        "#;
+
+        let authors = extract_authors(content).unwrap();
+        assert_eq!(authors.len(), 1);
+        let aff = &authors[0].affiliations[0];
+        assert_eq!(aff.id.as_deref(), Some("aff2"));
+        assert_eq!(
+            aff.institution.as_deref(),
+            Some(
+                "Department of Functional Genomics, Institute of Bioengineering, Lausanne, Switzerland"
+            )
+        );
+    }
+
+    #[test]
+    fn test_resolve_xref_affiliation_missing_keeps_rid() {
+        // Referenced <aff> is absent: keep the rid as the id, no bogus institution.
+        let content = r#"
+        <front>
+            <article-meta>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                        <name><surname>Doe</surname><given-names>John</given-names></name>
+                        <xref ref-type="aff" rid="aff9">9</xref>
+                    </contrib>
+                </contrib-group>
+            </article-meta>
+        </front>
+        "#;
+
+        let authors = extract_authors(content).unwrap();
+        assert_eq!(authors.len(), 1);
+        let aff = &authors[0].affiliations[0];
+        assert_eq!(aff.id.as_deref(), Some("aff9"));
+        assert_eq!(aff.institution, None);
+        assert_eq!(aff.department, None);
+        assert_eq!(aff.address, None);
+        assert_eq!(aff.country, None);
     }
 
     #[test]

--- a/pubmed-parser/tests/integration/parsing/snapshots/pmc_snapshots__PMC10821037.snap
+++ b/pubmed-parser/tests/integration/parsing/snapshots/pmc_snapshots__PMC10821037.snap
@@ -37,14 +37,14 @@ expression: article
           "affiliations": [
             {
               "id": "af1-vaccines-12-00072",
-              "institution": "af1-vaccines-12-00072",
+              "institution": "School of Medicine, University of Colima, Colima 28040, Mexico",
               "department": null,
               "address": null,
               "country": null
             },
             {
               "id": "af2-vaccines-12-00072",
-              "institution": "af2-vaccines-12-00072",
+              "institution": "General Hospital of Zone 1, Colima Delegation, Mexican Institute of Social Security, Villa de Álvarez, Colima 28984, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -77,7 +77,7 @@ expression: article
           "affiliations": [
             {
               "id": "af3-vaccines-12-00072",
-              "institution": "af3-vaccines-12-00072",
+              "institution": "Clinical Epidemiology Research Unit, Mexican Institute of Social Security, Villa de Alvarez, Colima 28984, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -98,7 +98,7 @@ expression: article
           "affiliations": [
             {
               "id": "af2-vaccines-12-00072",
-              "institution": "af2-vaccines-12-00072",
+              "institution": "General Hospital of Zone 1, Colima Delegation, Mexican Institute of Social Security, Villa de Álvarez, Colima 28984, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -123,7 +123,7 @@ expression: article
           "affiliations": [
             {
               "id": "af1-vaccines-12-00072",
-              "institution": "af1-vaccines-12-00072",
+              "institution": "School of Medicine, University of Colima, Colima 28040, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -144,7 +144,7 @@ expression: article
           "affiliations": [
             {
               "id": "af1-vaccines-12-00072",
-              "institution": "af1-vaccines-12-00072",
+              "institution": "School of Medicine, University of Colima, Colima 28040, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -169,14 +169,14 @@ expression: article
           "affiliations": [
             {
               "id": "af1-vaccines-12-00072",
-              "institution": "af1-vaccines-12-00072",
+              "institution": "School of Medicine, University of Colima, Colima 28040, Mexico",
               "department": null,
               "address": null,
               "country": null
             },
             {
               "id": "af4-vaccines-12-00072",
-              "institution": "af4-vaccines-12-00072",
+              "institution": "Cancerology State Institute, Colima State Health Services, Colima 28085, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -203,7 +203,7 @@ expression: article
           "affiliations": [
             {
               "id": "af5-vaccines-12-00072",
-              "institution": "af5-vaccines-12-00072",
+              "institution": "Research Center in Minority Institutions, Robert Stempel College of Public Health, Florida International University, Miami, FL 33199, USA",
               "department": null,
               "address": null,
               "country": null
@@ -228,7 +228,7 @@ expression: article
           "affiliations": [
             {
               "id": "af1-vaccines-12-00072",
-              "institution": "af1-vaccines-12-00072",
+              "institution": "School of Medicine, University of Colima, Colima 28040, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -253,7 +253,7 @@ expression: article
           "affiliations": [
             {
               "id": "af1-vaccines-12-00072",
-              "institution": "af1-vaccines-12-00072",
+              "institution": "School of Medicine, University of Colima, Colima 28040, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -278,7 +278,7 @@ expression: article
           "affiliations": [
             {
               "id": "af6-vaccines-12-00072",
-              "institution": "af6-vaccines-12-00072",
+              "institution": "Molecular Medicine Laboratory, Academic Unit of Human Medicine and Health Sciences, Autonomous University of Zacatecas, Zacatecas 98160, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -299,7 +299,7 @@ expression: article
           "affiliations": [
             {
               "id": "af1-vaccines-12-00072",
-              "institution": "af1-vaccines-12-00072",
+              "institution": "School of Medicine, University of Colima, Colima 28040, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -323,7 +323,7 @@ expression: article
           "affiliations": [
             {
               "id": "af7-vaccines-12-00072",
-              "institution": "af7-vaccines-12-00072",
+              "institution": "Molecular and Structural Physiology Laboratory, School of Biological Sciences, Autonomous University of Nuevo Leon, San Nicolas de los Garza 66455, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -344,7 +344,7 @@ expression: article
           "affiliations": [
             {
               "id": "af1-vaccines-12-00072",
-              "institution": "af1-vaccines-12-00072",
+              "institution": "School of Medicine, University of Colima, Colima 28040, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -368,7 +368,7 @@ expression: article
           "affiliations": [
             {
               "id": "af4-vaccines-12-00072",
-              "institution": "af4-vaccines-12-00072",
+              "institution": "Cancerology State Institute, Colima State Health Services, Colima 28085, Mexico",
               "department": null,
               "address": null,
               "country": null
@@ -392,21 +392,21 @@ expression: article
           "affiliations": [
             {
               "id": "af1-vaccines-12-00072",
-              "institution": "af1-vaccines-12-00072",
+              "institution": "School of Medicine, University of Colima, Colima 28040, Mexico",
               "department": null,
               "address": null,
               "country": null
             },
             {
               "id": "af4-vaccines-12-00072",
-              "institution": "af4-vaccines-12-00072",
+              "institution": "Cancerology State Institute, Colima State Health Services, Colima 28085, Mexico",
               "department": null,
               "address": null,
               "country": null
             },
             {
               "id": "af8-vaccines-12-00072",
-              "institution": "af8-vaccines-12-00072",
+              "institution": "Department of Dietetics and Nutrition, Robert Stempel College of Public Health and Social Work, Florida International University, Miami, FL 33199, USA",
               "department": null,
               "address": null,
               "country": null

--- a/pubmed-parser/tests/integration/parsing/snapshots/pmc_snapshots__PMC7906746.snap
+++ b/pubmed-parser/tests/integration/parsing/snapshots/pmc_snapshots__PMC7906746.snap
@@ -37,7 +37,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff1",
-              "institution": "aff1",
+              "institution": "Departamento de Molestias Infecciosas e Parasitarias and Instituto de Medicina Tropical da Faculdade de Medicina da Universidade de São Paulo, São Paulo, SP 05403–000, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -58,7 +58,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff1",
-              "institution": "aff1",
+              "institution": "Departamento de Molestias Infecciosas e Parasitarias and Instituto de Medicina Tropical da Faculdade de Medicina da Universidade de São Paulo, São Paulo, SP 05403–000, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -79,7 +79,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff2",
-              "institution": "aff2",
+              "institution": "Fundação Hospitalar de Hematologia e Hemoterapia do Amazonas, Manaus, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -100,7 +100,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff3",
-              "institution": "aff3",
+              "institution": "Departamento de Engenharia de Sistemas Eletrônicos, Escola Politécnica da Universidade de São Paulo, São Paulo, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -121,7 +121,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff2",
-              "institution": "aff2",
+              "institution": "Fundação Hospitalar de Hematologia e Hemoterapia do Amazonas, Manaus, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -142,7 +142,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff2",
-              "institution": "aff2",
+              "institution": "Fundação Hospitalar de Hematologia e Hemoterapia do Amazonas, Manaus, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -163,7 +163,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff4",
-              "institution": "aff4",
+              "institution": "Institute for Applied Economic Research–Ipea, Brasília, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -184,7 +184,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff5",
-              "institution": "aff5",
+              "institution": "MRC Centre for Global Infectious Disease Analysis, J-IDEA, Imperial College London, London, UK",
               "department": null,
               "address": null,
               "country": null
@@ -205,7 +205,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff6",
-              "institution": "aff6",
+              "institution": "Institute of Mathematics and Statistics, University of São Paulo, São Paulo, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -226,7 +226,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff7",
-              "institution": "aff7",
+              "institution": "Department of Zoology, University of Oxford, Oxford, UK",
               "department": null,
               "address": null,
               "country": null
@@ -247,7 +247,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff8",
-              "institution": "aff8",
+              "institution": "Center of Mathematics, Computing and Cognition–Universidade Federal do ABC, São Paulo, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -268,14 +268,14 @@ expression: article
           "affiliations": [
             {
               "id": "aff9",
-              "institution": "aff9",
+              "institution": "Fundação Hemominas–Fundação Centro de Hematologia e Hemoterapia de Minas Gerais, Belo Horizonte, Brazil",
               "department": null,
               "address": null,
               "country": null
             },
             {
               "id": "aff10",
-              "institution": "aff10",
+              "institution": "Faculdade Ciências Médicas de Minas Gerais, Belo Horizonte, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -296,7 +296,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff5",
-              "institution": "aff5",
+              "institution": "MRC Centre for Global Infectious Disease Analysis, J-IDEA, Imperial College London, London, UK",
               "department": null,
               "address": null,
               "country": null
@@ -317,7 +317,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff11",
-              "institution": "aff11",
+              "institution": "Department of Global Health and Population, Harvard T H Chan School of Public Health, Boston, MA, USA",
               "department": null,
               "address": null,
               "country": null
@@ -338,7 +338,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff12",
-              "institution": "aff12",
+              "institution": "Oxford School of Global and Area Studies, Latin American Centre, University of Oxford, Oxford, UK",
               "department": null,
               "address": null,
               "country": null
@@ -359,7 +359,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff3",
-              "institution": "aff3",
+              "institution": "Departamento de Engenharia de Sistemas Eletrônicos, Escola Politécnica da Universidade de São Paulo, São Paulo, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -380,7 +380,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff13",
-              "institution": "aff13",
+              "institution": "Centro de Ciências Ambientais, Universidade Federal do Amazonas, Manaus, Brazil",
               "department": null,
               "address": null,
               "country": null
@@ -401,7 +401,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff5",
-              "institution": "aff5",
+              "institution": "MRC Centre for Global Infectious Disease Analysis, J-IDEA, Imperial College London, London, UK",
               "department": null,
               "address": null,
               "country": null
@@ -422,7 +422,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff7",
-              "institution": "aff7",
+              "institution": "Department of Zoology, University of Oxford, Oxford, UK",
               "department": null,
               "address": null,
               "country": null
@@ -443,7 +443,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff14",
-              "institution": "aff14",
+              "institution": "Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene & Tropical Medicine, London, UK",
               "department": null,
               "address": null,
               "country": null
@@ -464,14 +464,14 @@ expression: article
           "affiliations": [
             {
               "id": "aff15",
-              "institution": "aff15",
+              "institution": "Vitalant Research Institute, San Francisco, CA, USA",
               "department": null,
               "address": null,
               "country": null
             },
             {
               "id": "aff16",
-              "institution": "aff16",
+              "institution": "University of California, San Francisco, CA, USA",
               "department": null,
               "address": null,
               "country": null
@@ -492,7 +492,7 @@ expression: article
           "affiliations": [
             {
               "id": "aff7",
-              "institution": "aff7",
+              "institution": "Department of Zoology, University of Oxford, Oxford, UK",
               "department": null,
               "address": null,
               "country": null
@@ -513,21 +513,21 @@ expression: article
           "affiliations": [
             {
               "id": "aff1",
-              "institution": "aff1",
+              "institution": "Departamento de Molestias Infecciosas e Parasitarias and Instituto de Medicina Tropical da Faculdade de Medicina da Universidade de São Paulo, São Paulo, SP 05403–000, Brazil",
               "department": null,
               "address": null,
               "country": null
             },
             {
               "id": "aff5",
-              "institution": "aff5",
+              "institution": "MRC Centre for Global Infectious Disease Analysis, J-IDEA, Imperial College London, London, UK",
               "department": null,
               "address": null,
               "country": null
             },
             {
               "id": "aff7",
-              "institution": "aff7",
+              "institution": "Department of Zoology, University of Oxford, Oxford, UK",
               "department": null,
               "address": null,
               "country": null


### PR DESCRIPTION
Previously the PMC author parser stored the affiliation cross-reference
`rid` as the institution and left department/address/country as `None`.
Now each `<xref ref-type="aff">` rid is resolved against the `<aff>`
elements in `<front>`, populating institution/department/address/country
with real text.

- Index all `<aff id="...">` blocks in the front matter (they are usually
  siblings of `<contrib-group>` inside `<article-meta>`).
- Populate structured fields from `<institution>` (with `content-type="dept"`
  routed to department), `<addr-line>`, and `<country>`; fall back to
  concatenated free text (label and email content dropped) otherwise.
- Keep the rid as the affiliation id when the referenced `<aff>` cannot be
  resolved, instead of reporting the rid as the institution.
- Add unit tests for structured, free-text, and unresolved cases; refresh
  PMC snapshots.

Closes #216