### PR TITLE
ci(python): type check at --strict in PR CI, not only at release

### DIFF
--- a/.github/workflows/_publish-python.yml
+++ b/.github/workflows/_publish-python.yml
@@ -195,6 +195,8 @@ jobs:
           uv run pytest -v -m "not integration"
 
       - name: Type check
+        # Same command as ci-python.yml's lint job; strictness lives in
+        # pyproject.toml's [tool.mypy] so the two cannot drift apart.
         run: |
           cd pubmed-client-py
-          uv run mypy tests/ --strict
+          uv run mypy .

--- a/pubmed-client-py/pyproject.toml
+++ b/pubmed-client-py/pyproject.toml
@@ -136,11 +136,12 @@ extend-select = [
 
 [tool.mypy]
 python_version = "3.12"
-warn_return_any = true
+# strict is what the release pipeline used to pass as `--strict` on the command
+# line. Keeping it in config means CI, the release pipeline, and `mise run
+# lint:py` all type check at the same strictness — a generated stub that only
+# --strict rejects (e.g. a bare `list` return) can no longer reach a release.
+strict = true
 warn_unused_configs = true
-check_untyped_defs = true
-disallow_untyped_defs = true
-disallow_untyped_calls = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Why

The v0.3.0 release failed to publish to PyPI. The `PyPI · build wheels / test` job runs `uv run mypy tests/ --strict`, which rejected the generated stub:

```
pubmed_client.pyi:674: error: Missing type parameters for generic type "list"  [type-arg]
pubmed_client.pyi:697: error: Missing type parameters for generic type "list"  [type-arg]
```

PR CI never saw it: `ci-python.yml`'s lint job runs a plain `uv run mypy .`, and `disallow_any_generics` — the check that flags a bare `list` — is only enabled by `--strict`. So the strictness gap between the two pipelines let a stub regression through every PR and only surfaced at publish time, after crates.io and npm had already gone out.

(The stub itself was fixed in be7c8b0; this PR closes the gap that let it reach a release.)

## What

- Move the strictness into `pubmed-client-py/pyproject.toml`'s `[tool.mypy]` (`strict = true`), instead of passing `--strict` on one pipeline's command line. `strict` subsumes the flags it replaces.
- Have the release pipeline call the same `uv run mypy .` as PR CI, so the two cannot drift apart again.

`mise run lint:py` picks this up for free — it already ran `mypy .`.

## Verification

- `mise run lint:py` — ruff, `mypy .` (12 files), `ty check` all clean under the new config.
- Reintroduced the bare `list` into `pubmed_client.pyi` and confirmed `uv run mypy .` now fails with the exact error that broke the release, then restored the stub.
- `actionlint` clean on the changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)