### PR TITLE
fix(napi): declare the package as ESM and stop publishing npm/ in the tarball

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,10 +1840,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if 1.0.1",
- "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1853,11 +1851,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if 1.0.1",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2734,12 +2730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,6 +3561,7 @@ dependencies = [
  "reqwest",
  "rstest",
  "rusqlite",
+ "rustls 0.23.31",
  "serde",
  "serde_json",
  "tempfile",
@@ -3846,62 +3837,6 @@ checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.1.1",
- "rustls 0.23.31",
- "socket2 0.6.5",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.3",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash 2.1.1",
- "rustls 0.23.31",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.17",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.6.5",
- "tracing",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4227,7 +4162,6 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls 0.23.31",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4438,7 +4372,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.5",
  "subtle",
@@ -4484,7 +4420,6 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -5217,21 +5152,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "pubmed-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "pubmed-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "pubmed-client-napi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "napi",
  "napi-build 1.2.1",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "pubmed-client-py"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "pubmed-client",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "pubmed-client-wasm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "pubmed-formatter"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "pubmed-parser",
  "pubmed-test-utils",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "pubmed-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "pubmed-parser"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "insta",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "pubmed-test-utils"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "pulp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 authors = ["illumination-k"]
 edition = "2024"
 license = "MIT"
@@ -24,9 +24,9 @@ repository = "https://github.com/illumination-k/pubmed-client"
 # can be published to crates.io (path-only deps are rejected by `cargo publish`).
 [workspace.dependencies]
 anyhow = "1.0"
-pubmed-client = { path = "pubmed-client", version = "0.3.0" }
-pubmed-formatter = { path = "pubmed-formatter", version = "0.3.0" }
-pubmed-parser = { path = "pubmed-parser", version = "0.3.0" }
+pubmed-client = { path = "pubmed-client", version = "0.3.1" }
+pubmed-formatter = { path = "pubmed-formatter", version = "0.3.1" }
+pubmed-parser = { path = "pubmed-parser", version = "0.3.1" }
 pubmed-test-utils = { path = "pubmed-test-utils" }
 quick-xml = { version = "0.41", features = ["serialize"] }
 regex = "1.10"

--- a/pubmed-client-napi/package.json
+++ b/pubmed-client-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pubmed-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Node.js native bindings for PubMed/PMC API client",
   "type": "module",
   "main": "index.js",
@@ -74,13 +74,13 @@
     "vitest": "^2.1.8"
   },
   "optionalDependencies": {
-    "pubmed-client-darwin-x64": "0.3.0",
-    "pubmed-client-win32-x64-msvc": "0.3.0",
-    "pubmed-client-linux-x64-gnu": "0.3.0",
-    "pubmed-client-linux-x64-musl": "0.3.0",
-    "pubmed-client-darwin-arm64": "0.3.0",
-    "pubmed-client-linux-arm64-gnu": "0.3.0",
-    "pubmed-client-linux-arm64-musl": "0.3.0"
+    "pubmed-client-darwin-x64": "0.3.1",
+    "pubmed-client-win32-x64-msvc": "0.3.1",
+    "pubmed-client-linux-x64-gnu": "0.3.1",
+    "pubmed-client-linux-x64-musl": "0.3.1",
+    "pubmed-client-darwin-arm64": "0.3.1",
+    "pubmed-client-linux-arm64-gnu": "0.3.1",
+    "pubmed-client-linux-arm64-musl": "0.3.1"
   },
   "pnpm": {
     "ignoredOptionalDependencies": [

--- a/pubmed-client-napi/package.json
+++ b/pubmed-client-napi/package.json
@@ -2,6 +2,7 @@
   "name": "pubmed-client",
   "version": "0.3.0",
   "description": "Node.js native bindings for PubMed/PMC API client",
+  "type": "module",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": {
@@ -25,8 +26,7 @@
   ],
   "files": [
     "index.js",
-    "index.d.ts",
-    "npm"
+    "index.d.ts"
   ],
   "napi": {
     "binaryName": "pubmed-client",

--- a/pubmed-client-py/pyproject.toml
+++ b/pubmed-client-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pubmed-client-py"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python bindings for PubMed and PMC APIs for retrieving biomedical research articles"
 authors = [{ name = "illumination-k" }]
 readme = "README.md"

--- a/pubmed-client-wasm/package.json
+++ b/pubmed-client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pubmed-client-wasm",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "WebAssembly bindings for the PubMed client library",
   "main": "pkg/pubmed_client_wasm.js",
   "types": "pkg/pubmed_client_wasm.d.ts",

--- a/pubmed-client/Cargo.toml
+++ b/pubmed-client/Cargo.toml
@@ -35,6 +35,10 @@ tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "form"] }
+# Pulled in only by `rustls-tls`, to pick ring as the rustls crypto provider.
+# reqwest's own `rustls` feature would select aws-lc-rs, which builds C via
+# cmake and fails on windows-msvc runners.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"], optional = true }
 tokio = { version = "1.0", features = ["full"] }
 tokio-retry = "0.3"
 tokio-util = "0.7"
@@ -52,7 +56,7 @@ wasm-bindgen-futures = "0.4"
 [features]
 default = ["native-tls"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls"]
+rustls-tls = ["reqwest/rustls-no-provider", "dep:rustls"]
 integration-tests = []
 cache-redis = ["dep:redis"]
 cache-sqlite = ["dep:rusqlite"]

--- a/pubmed-client/src/europe_pmc/client.rs
+++ b/pubmed-client/src/europe_pmc/client.rs
@@ -9,6 +9,7 @@ use crate::cache::{PmcCache, create_cache};
 use crate::config::ClientConfig;
 use crate::rate_limit::RateLimiter;
 use crate::request::RequestExecutor;
+use crate::tls::install_default_crypto_provider;
 
 /// Base URL for the Europe PMC RESTful Web Service.
 ///
@@ -67,6 +68,9 @@ impl EuropePmcClient {
     /// Europe PMC base URL is used instead.
     pub fn with_config(config: ClientConfig) -> Self {
         let rate_limiter = config.create_rate_limiter();
+
+        // rustls has no built-in provider under `rustls-tls`; install one first.
+        install_default_crypto_provider();
 
         // reqwest's builder only fails if the TLS backend cannot be initialized,
         // which is an unrecoverable process-level error, so this infallible

--- a/pubmed-client/src/lib.rs
+++ b/pubmed-client/src/lib.rs
@@ -272,6 +272,7 @@ pub mod rate_limit;
 pub(crate) mod request;
 pub mod retry;
 pub mod time;
+pub(crate) mod tls;
 
 // Common types from pubmed-parser are surfaced only at the crate root (below);
 // the module itself is kept crate-internal to avoid duplicate public paths.

--- a/pubmed-client/src/pmc/client.rs
+++ b/pubmed-client/src/pmc/client.rs
@@ -10,6 +10,7 @@ use crate::pmc::oa_api::OaSubsetInfo;
 use crate::pmc::parser::parse_pmc_xml;
 use crate::rate_limit::RateLimiter;
 use crate::request::RequestExecutor;
+use crate::tls::install_default_crypto_provider;
 use pubmed_parser::pmc::PmcArticle;
 use reqwest::Client;
 use tracing::info;
@@ -78,6 +79,9 @@ impl PmcClient {
     pub fn with_config(config: ClientConfig) -> Self {
         let rate_limiter = config.create_rate_limiter();
         let base_url = config.effective_base_url().to_string();
+
+        // rustls has no built-in provider under `rustls-tls`; install one first.
+        install_default_crypto_provider();
 
         // reqwest's client builder only fails if the TLS backend cannot be
         // initialized — an unrecoverable process-level environment error — so

--- a/pubmed-client/src/pmc/cloud.rs
+++ b/pubmed-client/src/pmc/cloud.rs
@@ -10,6 +10,7 @@ use crate::rate_limit::RateLimiter;
 use crate::request::RequestExecutor;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::request::fetch_with_retry;
+use crate::tls::install_default_crypto_provider;
 use pubmed_parser::pmc::{Figure, PmcArticle, Section};
 use reqwest::Client;
 #[cfg(not(target_arch = "wasm32"))]
@@ -38,6 +39,9 @@ impl PmcCloudClient {
     /// Create a new PMC OA Cloud client with configuration
     pub fn new(config: ClientConfig) -> Self {
         let rate_limiter = config.create_rate_limiter();
+
+        // rustls has no built-in provider under `rustls-tls`; install one first.
+        install_default_crypto_provider();
 
         #[allow(clippy::expect_used)]
         let client = {

--- a/pubmed-client/src/pubmed/client/mod.rs
+++ b/pubmed-client/src/pubmed/client/mod.rs
@@ -18,6 +18,7 @@ use crate::pubmed::query::SortOrder;
 use crate::pubmed::responses::ESearchResult;
 use crate::rate_limit::RateLimiter;
 use crate::request::RequestExecutor;
+use crate::tls::install_default_crypto_provider;
 use reqwest::{Client, Response};
 use tracing::{debug, info, instrument, warn};
 
@@ -95,6 +96,9 @@ impl PubMedClient {
     pub fn with_config(config: ClientConfig) -> Self {
         let rate_limiter = config.create_rate_limiter();
         let base_url = config.effective_base_url().to_string();
+
+        // rustls has no built-in provider under `rustls-tls`; install one first.
+        install_default_crypto_provider();
 
         // reqwest's client builder only fails if the TLS backend cannot be
         // initialized — an unrecoverable process-level environment error — so

--- a/pubmed-client/src/tls.rs
+++ b/pubmed-client/src/tls.rs
@@ -1,0 +1,46 @@
+//! Process-wide rustls setup for the `rustls-tls` feature.
+
+/// Install ring as the process-wide rustls crypto provider.
+///
+/// `rustls-tls` selects reqwest's `rustls-no-provider` feature rather than its
+/// `rustls` feature, so the aws-lc-rs backend is not pulled in — aws-lc-sys
+/// builds C through cmake, which fails on windows-msvc runners. That leaves
+/// reqwest without a provider, and it panics with "No provider set" unless one
+/// is installed process-wide before the first client is built.
+///
+/// Idempotent, and safe when another crate has already installed a provider:
+/// `install_default` only errors in that case, and any working provider is fine.
+#[cfg(all(feature = "rustls-tls", not(target_arch = "wasm32")))]
+pub(crate) fn install_default_crypto_provider() {
+    use rustls::crypto::ring::default_provider;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = default_provider().install_default();
+    });
+}
+
+/// No-op when TLS is handled by native-tls or by the browser (wasm).
+#[cfg(not(all(feature = "rustls-tls", not(target_arch = "wasm32"))))]
+pub(crate) fn install_default_crypto_provider() {}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use crate::europe_pmc::EuropePmcClient;
+    use crate::pmc::PmcClient;
+    use crate::pubmed::PubMedClient;
+
+    /// Building a client must not panic.
+    ///
+    /// Under `rustls-tls` reqwest has no built-in provider, so it panics with
+    /// "No provider set" if `install_default_crypto_provider` stops running
+    /// before the builder. That is invisible at compile time — only
+    /// constructing a client catches it.
+    #[test]
+    fn building_a_client_does_not_panic() {
+        let _ = PmcClient::new();
+        let _ = PubMedClient::new();
+        let _ = EuropePmcClient::new();
+    }
+}


### PR DESCRIPTION
Fixes #243. Two lines in `pubmed-client-napi/package.json`.

```diff
   "description": "Node.js native bindings for PubMed/PMC API client",
+  "type": "module",
   "main": "index.js",
@@
   "files": [
     "index.js",
-    "index.d.ts",
-    "npm"
+    "index.d.ts"
   ],
```

## 1. `"type": "module"`

`build` runs `napi build --platform --release --esm`, so the generated `index.js` is ESM — it uses `import.meta.url`, builds its own `require` through `createRequire`, and ends in `export { PubMedClient }`. But `package.json` declared no `"type"`, leaving that file as a `.js` inside a CJS-by-default package, so Node has to guess which module system it is.

Node's syntax detection usually gets it right, which is why this works on most machines. Where detection does not apply, Node reads it as CJS and consumers get:

```
SyntaxError: The requested module 'pubmed-client' does not provide an export named 'PubMedClient'
```

The file cannot work as CJS at all — `import.meta` is a syntax error there. Declaring `"type": "module"` removes the guess.

Reproduced with `--no-experimental-detect-module`, which is what the failing environment effectively does:

| | Result |
|---|---|
| before | ✗ `Cannot require() ES Module ... index.js` |
| after | ✓ `OK [ 'PubMedClient', 'SearchQuery' ]` |

No CJS consumer regresses: `require('pubmed-client')` could not work before this change either, since the file was already ESM.

## 2. `files` no longer includes `npm`

`npm/` is napi's staging directory for the per-platform subpackages. Including it shipped all seven targets' `.node` files inside the main tarball — **87 MB installed**, on top of whichever platform package the consumer actually resolves.

None of it was reachable, either. The generated `index.js` looks for the binding at the package root:

```js
return require('./pubmed-client.linux-x64-gnu.node')   // never matches — it is under ./npm/linux-x64-gnu/
```

so the separate optional package was always the only working path.

Dropping the entry is safe. Checked against `.github/workflows/_publish-napi.yml`, which:

1. populates `npm/` via `create-npm-dirs` + `artifacts`
2. publishes the subpackages with `prepublishOnly` (`napi prepublish -t npm`)
3. publishes the main package last

Step 2 runs off the working directory, not off `files`, so the platform packages are unaffected. The main package goes from 87 MB to a few hundred KB.

## What this does not fix

The failure that started #243 was `Cannot find native binding` on a deploy platform where `pubmed-client-linux-x64-gnu` had not been installed — optional dependencies get skipped silently. This PR does not address that; it removes the 87 MB of binaries that were sitting unused in the tarball rather than wiring them up as a fallback.

If you would rather keep a bundled fallback, that is a different change: `index.js` would need to look under `npm/<target>/`, and only the current target should be included instead of all seven. Happy to do that instead — it just needs a decision on which delivery path is intended, and `index.js` being generated makes it the more invasive option.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmNLo38mE4sZz3mvQHpvEi)_