### PR TITLE
refactor: dedupe Europe PMC pagination, cover cache backends, refresh docs

### DIFF
--- a/.claude/skills/code-health/SKILL.md
+++ b/.claude/skills/code-health/SKILL.md
@@ -41,7 +41,7 @@ crate.
 1. **Start with `hotspot`.** It ranks `commits × cognitive_max` — "frequently changed
    _and_ complex". The top ~5 files are where bugs concentrate and refactors pay off.
 2. **Drill into `complexity`** for those files. The per-function list gives exact line
-   ranges (`file:Func (L238-317): cog=50`). Sort by **cognitive**, not cyclomatic.
+   ranges (`file:Func (L238-317): cog=33`). Sort by **cognitive**, not cyclomatic.
 3. **Cross-check `similarity` + `wrapper`** to see whether the complexity is genuine
    logic or copy-paste / thin forwarding that should be unified.
 4. **For structure questions, run `coupling`.** Read `instability` (`Ce/(Ca+Ce)`),
@@ -76,9 +76,9 @@ boilerplate** — learn to skip them so the real findings stand out.
 - **`PmcArticle::doi`/`title`/`volume`/… in `pmc/domain.rs`** forwarding to nested
   `front.article_meta.*` are the **flat accessor layer** CLAUDE.md describes ("Single
   PMC model layer; flat read access via accessor methods"). Intentional.
-- **Builder-setter cohesion** — `WasmClientConfig` (LCOM4=5), `ClientConfig` (LCOM4=6),
-  `RetryConfig` — each `with_*` setter touches a different field, so a high LCOM4 is the
-  expected shape of a builder, not a defect.
+- **Builder-setter cohesion** — `WasmClientConfig`, `ClientConfig`, `RetryConfig`, and
+  the Go `SearchQuery` — each `with_*` / recorded setter touches a different field, so a
+  high LCOM4 is the expected shape of a builder, not a defect.
 - **`SearchQuery::published_between` / `entry_date_between` / `modification_date_between`**
   (≈98% similar) and `and`/`or`, `negate`/`group` in `query/boolean.rs` are
   builder-pattern variants. A shared private helper is _possible_ but low-value/low-risk.
@@ -87,26 +87,48 @@ boilerplate** — learn to skip them so the real findings stand out.
 
 ### Real, actionable signal
 
-- **`pubmed-parser/src/pmc/parser/` is the complexity epicentre.**
-  `author.rs:extract_reference_authors` (cog=50, the workspace max),
-  `section.rs:parse_section_from_body` (cog=39) and `extract_body_sections` (cog=29),
-  `xml_utils.rs:decode_xml_entities` (cog=37). `section.rs`, `metadata.rs`, `author.rs`
-  are also top hotspots. These are genuine parsing logic — split/simplify candidates.
-- **`pubmed-client/src/pmc/tar.rs` is the #1 hotspot** (score 340, heavy churn +
-  `find_matching_file` cog=34). Watch this file on every change.
+Named files below are where the debt sat at the last full sweep. Treat them as a
+starting point, not a current inventory — **re-run the profile before quoting a
+number.** The open findings, with their evidence, live under the umbrella issue
+[#254](https://github.com/illumination-k/pubmed-client/issues/254).
+
+- **`pubmed-parser/src/pmc/parser/` is the complexity epicentre**, and has been across
+  successive sweeps. `metadata.rs` and `section.rs` take the top two `hotspot` slots
+  (both ~1300-1450 LOC, `commits × cognitive_max` within a few points of each other),
+  and the workspace's densest Rust functions are the JATS element readers inside them —
+  `metadata.rs:extract_abstract`, `section.rs:extract_body_sections`,
+  `section.rs:read_paragraph_with_inline`. Genuine parsing logic, so the fix is
+  splitting by JATS element group, not clever-ing the loops (#205, #249).
+  - Ignore the `cognitive` max in the raw report if it points at
+    `pubmed-client-py/examples/*.py` — the Python examples are deliberately linear
+    display code and outrank every Rust function.
+- **`hubs` flags `parse_pmc_xml` as the only Henry-Kafura bottleneck** (fan_out ≈ 33 —
+  it calls every extractor). That is the shape of an assembler, and it should shrink on
+  its own once the two files above are split. Re-measure after, don't pre-emptively cut.
 - **Genuine accidental duplicates** worth unifying (same logic, _within the Rust core_):
-  - `format_first_pub_date` is **100% duplicated** across
-    `pubmed-formatter/src/pmc/markdown/frontmatter.rs` and `.../markdown/metadata.rs`.
-  - `format_author_name` is ~94% duplicated across `pubmed-parser/src/common/models.rs`
-    and `pubmed-parser/src/pubmed/parser/extractors.rs`.
   - `PubMedId::try_from_u32` / `PmcId::try_from_u32` in `common/ids.rs` and
     `PmcXmlTestCase::new` / `PubMedXmlTestCase::new` in `pubmed-test-utils` are
     type-paired — macro candidates if the pattern grows.
+  - `pubmed-cli/src/commands/`: `Citations::execute` ≈ `Related::execute` (~94%);
+    `pubmed-mcp/src/tools/elink.rs`: `get_related_articles` ≈ `get_citations` (~90%).
+    Both pairs differ only in which ELink call they make (#252, #209).
+  - **The pattern to copy** when unifying a set of same-shaped endpoints is
+    `pubmed-client/src/europe_pmc/paged.rs`: one private generic helper plus a small
+    trait, with the per-endpoint public methods kept as-is so the API does not move.
 - **`wrapper` to shared helpers** is actionable when a thin per-module wrapper exists
   only to forward to a canonical helper (e.g. `PmcClient::normalize_pmcid` →
   `common::normalize_pmcid`). The repo prefers one unified helper over parallel variants.
+- **`visibility` is worth a periodic pass on `pubmed-parser`.** Parser-internal helpers
+  (`pmc/parser/reader_utils.rs`, `common/xml_utils.rs`) are `pub` while every caller is
+  in-crate, so they are published API by accident. Narrowing is compiler-verified — a
+  wrong row costs a failed build, not lost code — but it is still a semver-visible
+  change, so batch it into a minor bump (#251).
+- **`untested` is an upper bound, so verify by hand before filing.** Most rows are
+  integration-tested through call sites the static graph cannot attribute. The way to
+  confirm a real gap is to grep the test tree for the type, as with the SQLite/Redis
+  cache backends (#253) — flagged _and_ genuinely untested.
 - **`coupling` on `pubmed-client`**: `crate::error` is a high-Fan-In/low-Fan-Out stable
-  hub (healthy); `pmc::client` / `pmc::tar` are intentionally high-instability leaves.
+  hub (healthy); `pmc::client` / `pmc::cloud` are intentionally high-instability leaves.
   The signal to watch is **cycle count > 0** (currently 0) — flag any new cross-crate
   cycle or new dependency that inverts the `parser → formatter → client` layering.
 
@@ -116,3 +138,18 @@ Adjust thresholds in [`agent-lens.toml`](../../../agent-lens.toml), or override
 per-invocation with `agent-lens analyze <tool> <path> --format md` flags
 (`--threshold`, `--min-lines`, `--top`, `--diff-only`, `--since`, `--exclude`). Full
 reference: `agent-lens help --md`.
+
+Beyond the four profiles, these one-off analyzers have earned their keep here:
+`visibility` (over-exposed `pub`), `untested` (missing test paths), `hubs`
+(bottlenecks / feature envy), `cycles`, `delegation`, and `risk` (churn × blast
+radius — read it as "check callers before editing", not as a defect list).
+
+To turn a profile into a gate once the current debt is paid down, snapshot it:
+
+```bash
+agent-lens baseline create quality > .agent-lens/baseline-quality.json
+agent-lens baseline compare quality .agent-lens/baseline-quality.json   # exit 2 on regression
+```
+
+Snapshotting before the #205 / #249 splits land would bake today's complexity tail in
+as acceptable, so hold off until then.

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Run unit tests
         run: mise run test:rs
 
+      # The default feature set does not compile the Redis / SQLite cache
+      # backends, so they need their own run to be covered by this job.
+      - name: Run cache backend tests
+        run: mise run test:rs:cache-backends
+
       # pubmed-client-py is excluded from doc tests since its doc written for Python Users
       - name: Run doc tests
         run: mise run doctest:rs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ pubmed-client-rs/                    # Cargo workspace root
 ├── pubmed-client-r/                 # R bindings via extendr (R package: pubmedclient) — NOT a workspace member
 ├── pubmed-cli/                      # Command-line interface
 ├── pubmed-mcp/                      # MCP server for AI assistant integration
+├── pubmed-test-utils/               # Shared XML fixture loaders for tests (crate: pubmed-test-utils, not published)
 └── website/                         # Docusaurus v3 landing page (GitHub Pages)
 ```
 
@@ -131,7 +132,7 @@ The codebase is split into three core Rust crates with a clear layering:
 ### Parser (`pubmed-parser/src/`)
 
 ```
-lib.rs                 # Re-exports: common, error, pmc, pubmed modules
+lib.rs                 # Re-exports: common, error, europe_pmc, pmc, pubmed modules
 error.rs               # ParseError enum and Result type alias
 
 common/                # Shared types between PubMed and PMC
@@ -161,7 +162,16 @@ pmc/                   # PMC XML parsing
     metadata.rs        # Metadata extraction
     reference.rs       # Reference extraction
     section.rs         # Section parsing
-    xml_utils.rs       # XML utilities
+    reader_utils.rs    # quick-xml reader helpers shared by metadata.rs / section.rs
+    xml_utils.rs       # Re-export shim over common/xml_utils.rs
+
+europe_pmc/            # Europe PMC JSON response models & parsers
+  models.rs            # EuropePmcResult and shared record fields
+  search.rs            # EuropePmcSearchResponse, parse_search_response
+  references.rs        # EuropePmcReference(List), parse_references_response
+  citations.rs         # EuropePmcCitation(List), parse_citations_response
+  links.rs             # EuropePmcDatabaseLink(List), parse_database_links_response
+  de.rs                # Custom serde deserializers for Europe PMC quirks
 ```
 
 ### Formatter (`pubmed-formatter/src/`)
@@ -174,9 +184,16 @@ pubmed/
                        # Batch helpers: articles_to_bibtex(), articles_to_ris(), articles_to_csl_json()
 
 pmc/
-  markdown.rs          # PmcMarkdownConverter (builder pattern)
-                       # MarkdownConfig, HeadingStyle, ReferenceStyle
-                       # Supports: TOC, YAML frontmatter, figure paths, ORCID links
+  markdown/            # PmcMarkdownConverter (builder pattern)
+    mod.rs             # PmcMarkdownConverter, convert(), convert_with_figures()
+    config.rs          # MarkdownConfig, HeadingStyle, ReferenceStyle
+    frontmatter.rs     # YAML frontmatter generation
+    metadata.rs        # Title / authors / journal / DOI block
+    sections.rs        # Body sections, figures, tables
+    references.rs      # Reference list rendering
+    heading.rs         # Heading style formatting
+    toc.rs             # Table of contents
+    entities.rs        # XML entity / inline markup cleanup
 ```
 
 ### Client (`pubmed-client/src/`)
@@ -187,8 +204,11 @@ cache.rs               # Response caching (pluggable: memory/Redis/SQLite)
 config.rs              # ClientConfig (API keys, rate limiting, caching, timeouts)
 error.rs               # PubMedError enum (wraps ParseError from pubmed-parser)
 rate_limit.rs          # Token bucket rate limiter for NCBI API compliance
+request.rs             # RequestExecutor — URL building + rate limit + retry + error mapping,
+                       # shared by every endpoint module in the crate
 retry.rs               # Retry with exponential backoff
 time.rs                # Cross-platform time utilities (native + WASM)
+tls.rs                 # rustls crypto provider installation (rustls-tls feature)
 
 pubmed/                # PubMed E-utilities API
   client/              # PubMedClient (split into focused modules)
@@ -214,6 +234,19 @@ pubmed/                # PubMed E-utilities API
 pmc/                   # PMC (PubMed Central) API
   client.rs            # PmcClient - full-text fetch, availability check, figure extraction
   cloud.rs             # PmcCloudClient - per-file download from the PMC OA Cloud (AWS S3)
+  common.rs            # Shared PMC helpers (normalize_pmcid, ...)
+  extracted.rs         # ExtractedFigure / downloaded-file result types
+
+europe_pmc/            # Europe PMC REST API (EBI; complements NCBI E-utilities)
+  client.rs            # EuropePmcClient - construction, cache, executor plumbing
+  id.rs                # EuropePmcId / EuropePmcSource — (source, id) addressing
+  search.rs            # Cross-source search (cursorMark pagination)
+  fulltext.rs          # JATS full text -> PmcArticle, and raw XML
+  paged.rs             # PagedList trait + shared page-number pagination
+  references.rs        # /references endpoint
+  citations.rs         # /citations endpoint
+  links.rs             # /databaseLinks endpoint
+  supplementary.rs     # Supplementary file download (non-WASM)
 ```
 
 ### Key Types
@@ -221,9 +254,10 @@ pmc/                   # PMC (PubMed Central) API
 - `Client` — Unified client with `pubmed` and `pmc` fields; convenience methods: `search_with_full_text`, `fetch_articles`, `fetch_summaries`, `search_and_fetch_summaries`, `get_related_articles`, `get_pmc_links`, `get_citations`, `match_citations`, `global_query`, `get_database_list`, `get_database_info`, `epost`, `fetch_all_by_pmids`, `spell_check`
 - `PubMedClient` — Search, fetch metadata, ESummary, EPost/History, ELink, EInfo, ECitMatch, EGQuery, ESpell
 - `PmcClient` — Fetch full-text, check availability, extract figures, download OA files from the PMC OA Cloud (AWS S3)
+- `EuropePmcClient` — Europe PMC REST API: cross-source search, JATS full text, references/citations/database links, supplementary downloads. Addressed by `EuropePmcId` (`(source, id)`); needs no API key
 - `SearchQuery` — Builder pattern for complex queries with filters, date ranges, boolean logic
 - `PubMedArticle` — Article metadata (title, authors, abstract, MeSH, keywords, etc.) — defined in `pubmed-parser`
-- `PmcFullText` — Structured full-text (sections, references, figures, tables) — defined in `pubmed-parser`
+- `PmcArticle` — Structured JATS full-text (front/body/back; sections, references, figures, tables) — defined in `pubmed-parser`
 - `PmcMarkdownConverter` — Configurable markdown output with YAML frontmatter — defined in `pubmed-formatter`
 - `ExportFormat` — Trait for BibTeX/RIS/CSL-JSON/NBIB export — defined in `pubmed-formatter`
 - `ClientConfig` — API key, email, tool name, rate limit, cache (memory/Redis/SQLite), timeout, retry config

--- a/mise.rust.toml
+++ b/mise.rust.toml
@@ -31,6 +31,13 @@ run = [
 description = "Run tests for entire workspace using nextest"
 run = ["cargo nextest run --workspace"]
 
+[tasks."test:rs:cache-backends"]
+description = "Run pubmed-client tests with the optional cache backends enabled"
+# `test:rs` builds with default features, so the `cache-redis` / `cache-sqlite`
+# code is not even compiled there. Only the coverage job (`--all-features`) used
+# to reach it, which meant a broken backend could pass the Test Suite job.
+run = ["cargo nextest run -p pubmed-client --features cache-sqlite,cache-redis"]
+
 [tasks."doctest:rs"]
 description = "Run doc tests for entire workspace"
 run = ["cargo test --doc --workspace --exclude pubmed-client-py"]
@@ -72,4 +79,4 @@ samply record target/profiling/examples/profile_parsing {{arg(i=0, name='mode', 
 
 [tasks."ci:rs"]
 description = "Equivalent to rust.yml: unit tests + doc tests"
-depends = ["lint:rs", "test:rs", "doctest:rs"]
+depends = ["lint:rs", "test:rs", "test:rs:cache-backends", "doctest:rs"]

--- a/pubmed-client/src/cache.rs
+++ b/pubmed-client/src/cache.rs
@@ -500,4 +500,225 @@ mod tests {
         cache.sync().await;
         assert_eq!(cache.entry_count(), 0);
     }
+
+    // -----------------------------------------------------------------------
+    // create_cache — backend selection and fallback
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_create_cache_memory_backend() {
+        let cache = create_cache(&CacheConfig::default());
+        assert_eq!(cache.entry_count(), 0);
+    }
+
+    /// The SQLite arm must actually build a `SqliteCache`, not silently fall
+    /// back to memory. `SqliteCache::new` is the only thing that creates the
+    /// `cache` table, so the table's existence is the observable proof.
+    #[cfg(feature = "cache-sqlite")]
+    #[test]
+    fn test_create_cache_sqlite_backend_initializes_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cache.sqlite");
+
+        let cache = create_cache(&CacheConfig {
+            backend: CacheBackendConfig::Sqlite { path: path.clone() },
+            ..Default::default()
+        });
+        assert_eq!(cache.entry_count(), 0);
+
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        let table: String = conn
+            .query_row(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'cache'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("create_cache should have created the `cache` table");
+        assert_eq!(table, "cache");
+    }
+
+    /// An unopenable database path must degrade to the memory backend rather
+    /// than panicking — the fallback documented on `create_cache`.
+    #[cfg(feature = "cache-sqlite")]
+    #[test]
+    fn test_create_cache_sqlite_falls_back_to_memory_on_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing-dir").join("cache.sqlite");
+
+        let cache = create_cache(&CacheConfig {
+            backend: CacheBackendConfig::Sqlite { path: path.clone() },
+            ..Default::default()
+        });
+
+        assert!(!path.exists(), "the SQLite path must not have been created");
+        assert_eq!(cache.entry_count(), 0);
+    }
+
+    /// A malformed Redis URL fails in `Client::open`, with no server involved,
+    /// so the fallback arm is reachable offline.
+    #[cfg(feature = "cache-redis")]
+    #[test]
+    fn test_create_cache_redis_falls_back_to_memory_on_bad_url() {
+        let cache = create_cache(&CacheConfig {
+            backend: CacheBackendConfig::Redis {
+                url: "not-a-redis-url".to_string(),
+            },
+            ..Default::default()
+        });
+        assert_eq!(cache.entry_count(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // SQLite backend
+    // -----------------------------------------------------------------------
+
+    #[cfg(feature = "cache-sqlite")]
+    fn sqlite_cache(dir: &tempfile::TempDir, ttl: Duration) -> TypedCache<String> {
+        let path = dir.path().join("cache.sqlite");
+        TypedCache::new(SqliteCache::<String>::new(&path, ttl).unwrap())
+    }
+
+    #[cfg(feature = "cache-sqlite")]
+    #[tokio::test]
+    async fn test_sqlite_cache_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = sqlite_cache(&dir, Duration::from_secs(60));
+
+        assert_eq!(cache.get("key1").await, None);
+
+        cache.insert("key1".to_string(), "value1".to_string()).await;
+        assert_eq!(cache.get("key1").await, Some("value1".to_string()));
+        assert_eq!(cache.get("nonexistent").await, None);
+    }
+
+    /// `INSERT OR REPLACE` semantics: a second insert must overwrite, not
+    /// collide on the primary key and leave the old value in place.
+    #[cfg(feature = "cache-sqlite")]
+    #[tokio::test]
+    async fn test_sqlite_cache_insert_replaces_existing_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = sqlite_cache(&dir, Duration::from_secs(60));
+
+        cache.insert("key1".to_string(), "first".to_string()).await;
+        cache.insert("key1".to_string(), "second".to_string()).await;
+
+        assert_eq!(cache.get("key1").await, Some("second".to_string()));
+        assert_eq!(cache.entry_count(), 1);
+    }
+
+    /// A zero TTL stamps `expires_at` at the current second, and the read
+    /// predicate is `expires_at > now`, so the entry is already stale on
+    /// insert. This pins the expiry filter without sleeping.
+    #[cfg(feature = "cache-sqlite")]
+    #[tokio::test]
+    async fn test_sqlite_cache_expired_entry_is_a_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = sqlite_cache(&dir, Duration::ZERO);
+
+        cache.insert("key1".to_string(), "value1".to_string()).await;
+
+        assert_eq!(cache.get("key1").await, None);
+        assert_eq!(
+            cache.entry_count(),
+            0,
+            "entry_count must exclude expired rows"
+        );
+    }
+
+    #[cfg(feature = "cache-sqlite")]
+    #[tokio::test]
+    async fn test_sqlite_cache_clear_and_entry_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = sqlite_cache(&dir, Duration::from_secs(60));
+
+        assert_eq!(cache.entry_count(), 0);
+
+        cache.insert("key1".to_string(), "value1".to_string()).await;
+        cache.insert("key2".to_string(), "value2".to_string()).await;
+        assert_eq!(cache.entry_count(), 2);
+
+        cache.clear().await;
+        assert_eq!(cache.entry_count(), 0);
+        assert_eq!(cache.get("key1").await, None);
+    }
+
+    /// The point of the SQLite backend over the memory one: entries outlive the
+    /// process. A fresh handle on the same file must see the earlier write.
+    #[cfg(feature = "cache-sqlite")]
+    #[tokio::test]
+    async fn test_sqlite_cache_persists_across_instances() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cache.sqlite");
+
+        {
+            let cache = TypedCache::new(
+                SqliteCache::<String>::new(&path, Duration::from_secs(60)).unwrap(),
+            );
+            cache.insert("key1".to_string(), "value1".to_string()).await;
+        }
+
+        let reopened =
+            TypedCache::new(SqliteCache::<String>::new(&path, Duration::from_secs(60)).unwrap());
+        assert_eq!(reopened.get("key1").await, Some("value1".to_string()));
+        assert_eq!(reopened.entry_count(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Redis backend
+    // -----------------------------------------------------------------------
+
+    /// `RedisCache::new` only parses the URL — no connection is opened — so
+    /// rejection of a malformed URL is verifiable without a server.
+    #[cfg(feature = "cache-redis")]
+    #[test]
+    fn test_redis_cache_new_rejects_invalid_url() {
+        assert!(RedisCache::<String>::new("not-a-redis-url", Duration::from_secs(60)).is_err());
+        assert!(RedisCache::<String>::new("redis://127.0.0.1/", Duration::from_secs(60)).is_ok());
+    }
+
+    /// An unreachable Redis must degrade to a miss, never an error or a panic:
+    /// every `RedisCache` method swallows connection failures by design.
+    #[cfg(feature = "cache-redis")]
+    #[tokio::test]
+    async fn test_redis_cache_unreachable_server_degrades_to_miss() {
+        // Port 1 is reserved and never listening.
+        let cache = TypedCache::new(
+            RedisCache::<String>::new("redis://127.0.0.1:1/", Duration::from_secs(60)).unwrap(),
+        );
+
+        cache.insert("key1".to_string(), "value1".to_string()).await;
+        assert_eq!(cache.get("key1").await, None);
+        cache.clear().await;
+        assert_eq!(cache.entry_count(), 0);
+    }
+
+    /// Round-trip against a real server. Requires `REDIS_URL` and is `#[ignore]`d
+    /// by default:
+    ///
+    /// ```sh
+    /// docker run --rm -p 6379:6379 redis
+    /// REDIS_URL=redis://127.0.0.1/ cargo test -p pubmed-client \
+    ///     --features cache-redis -- --ignored redis
+    /// ```
+    ///
+    /// It calls `FLUSHDB`, so point it at a throwaway database only.
+    #[cfg(feature = "cache-redis")]
+    #[tokio::test]
+    #[ignore = "requires a running Redis server; set REDIS_URL"]
+    async fn test_redis_cache_round_trip() {
+        let Ok(url) = std::env::var("REDIS_URL") else {
+            panic!("REDIS_URL must be set to run this test");
+        };
+        let cache =
+            TypedCache::new(RedisCache::<String>::new(&url, Duration::from_secs(60)).unwrap());
+
+        cache.clear().await;
+        assert_eq!(cache.get("key1").await, None);
+
+        cache.insert("key1".to_string(), "value1".to_string()).await;
+        assert_eq!(cache.get("key1").await, Some("value1".to_string()));
+
+        cache.clear().await;
+        assert_eq!(cache.get("key1").await, None);
+    }
 }

--- a/pubmed-client/src/europe_pmc/citations.rs
+++ b/pubmed-client/src/europe_pmc/citations.rs
@@ -10,7 +10,22 @@ use crate::error::Result;
 
 use super::client::EuropePmcClient;
 use super::id::EuropePmcId;
-use super::references::DEFAULT_PAGE_SIZE;
+use super::paged::PagedList;
+
+/// Path segment of the `citations` list endpoint.
+const SEGMENT: &str = "citations";
+
+impl PagedList for EuropePmcCitationList {
+    type Item = EuropePmcCitation;
+
+    fn hit_count(&self) -> u64 {
+        self.hit_count
+    }
+
+    fn into_items(self) -> Vec<Self::Item> {
+        self.citations
+    }
+}
 
 impl EuropePmcClient {
     /// Fetch a single page of the citation list (citing articles) for a record.
@@ -21,39 +36,14 @@ impl EuropePmcClient {
         page: u32,
         page_size: u32,
     ) -> Result<EuropePmcCitationList> {
-        let endpoint = format!("{}/{}/citations", id.source, id.id);
-        let page = page.to_string();
-        let page_size = page_size.to_string();
-        let response = self
-            .executor()
-            .get_endpoint(
-                &self.base_url,
-                &endpoint,
-                &[
-                    ("format", "json"),
-                    ("page", page.as_str()),
-                    ("pageSize", page_size.as_str()),
-                ],
-            )
-            .await?;
-        let text = response.text().await?;
-        Ok(parse_citations_response(&text)?)
+        self.get_list_page(id, SEGMENT, page, page_size, parse_citations_response)
+            .await
     }
 
     /// Fetch all citing articles for a record, following page numbers until exhausted.
     #[instrument(skip(self), fields(id = %id))]
     pub async fn get_citations(&self, id: &EuropePmcId) -> Result<Vec<EuropePmcCitation>> {
-        let mut collected = Vec::new();
-        let mut page = 1;
-        loop {
-            let list = self.get_citations_page(id, page, DEFAULT_PAGE_SIZE).await?;
-            let count = list.citations.len();
-            collected.extend(list.citations);
-            if count < DEFAULT_PAGE_SIZE as usize || collected.len() as u64 >= list.hit_count {
-                break;
-            }
-            page += 1;
-        }
-        Ok(collected)
+        self.collect_list_pages(id, SEGMENT, parse_citations_response)
+            .await
     }
 }

--- a/pubmed-client/src/europe_pmc/links.rs
+++ b/pubmed-client/src/europe_pmc/links.rs
@@ -10,7 +10,22 @@ use crate::error::Result;
 
 use super::client::EuropePmcClient;
 use super::id::EuropePmcId;
-use super::references::DEFAULT_PAGE_SIZE;
+use super::paged::PagedList;
+
+/// Path segment of the `databaseLinks` list endpoint.
+const SEGMENT: &str = "databaseLinks";
+
+impl PagedList for EuropePmcDatabaseLinkList {
+    type Item = EuropePmcDatabaseLink;
+
+    fn hit_count(&self) -> u64 {
+        self.hit_count
+    }
+
+    fn into_items(self) -> Vec<Self::Item> {
+        self.links
+    }
+}
 
 impl EuropePmcClient {
     /// Fetch a single page of external database cross-references for a record.
@@ -21,41 +36,14 @@ impl EuropePmcClient {
         page: u32,
         page_size: u32,
     ) -> Result<EuropePmcDatabaseLinkList> {
-        let endpoint = format!("{}/{}/databaseLinks", id.source, id.id);
-        let page = page.to_string();
-        let page_size = page_size.to_string();
-        let response = self
-            .executor()
-            .get_endpoint(
-                &self.base_url,
-                &endpoint,
-                &[
-                    ("format", "json"),
-                    ("page", page.as_str()),
-                    ("pageSize", page_size.as_str()),
-                ],
-            )
-            .await?;
-        let text = response.text().await?;
-        Ok(parse_database_links_response(&text)?)
+        self.get_list_page(id, SEGMENT, page, page_size, parse_database_links_response)
+            .await
     }
 
     /// Fetch all external database cross-references for a record.
     #[instrument(skip(self), fields(id = %id))]
     pub async fn get_database_links(&self, id: &EuropePmcId) -> Result<Vec<EuropePmcDatabaseLink>> {
-        let mut collected = Vec::new();
-        let mut page = 1;
-        loop {
-            let list = self
-                .get_database_links_page(id, page, DEFAULT_PAGE_SIZE)
-                .await?;
-            let count = list.links.len();
-            collected.extend(list.links);
-            if count < DEFAULT_PAGE_SIZE as usize || collected.len() as u64 >= list.hit_count {
-                break;
-            }
-            page += 1;
-        }
-        Ok(collected)
+        self.collect_list_pages(id, SEGMENT, parse_database_links_response)
+            .await
     }
 }

--- a/pubmed-client/src/europe_pmc/mod.rs
+++ b/pubmed-client/src/europe_pmc/mod.rs
@@ -15,6 +15,7 @@ mod client;
 mod fulltext;
 mod id;
 mod links;
+mod paged;
 mod references;
 mod search;
 #[cfg(not(target_arch = "wasm32"))]

--- a/pubmed-client/src/europe_pmc/paged.rs
+++ b/pubmed-client/src/europe_pmc/paged.rs
@@ -1,0 +1,92 @@
+//! Shared page-number pagination for the Europe PMC list endpoints.
+//!
+//! `references`, `citations` and `databaseLinks` are the same endpoint shape:
+//! `/{source}/{id}/{segment}?format=json&page=N&pageSize=M`, answered by a JSON
+//! object carrying a total `hitCount` and one page of items. Only the path
+//! segment, the response type and its item field differ, so the request and the
+//! page-walking loop live here once and each endpoint module supplies the three
+//! things that actually vary.
+
+use pubmed_parser::Result as ParseResult;
+
+use crate::error::Result;
+
+use super::client::EuropePmcClient;
+use super::id::EuropePmcId;
+
+/// Default page size for reference / citation / database-link pagination.
+pub(crate) const DEFAULT_PAGE_SIZE: u32 = 100;
+
+/// One page of a page-numbered Europe PMC list response.
+///
+/// Implemented by the `*List` models in [`pubmed_parser::europe_pmc`] so
+/// [`EuropePmcClient::collect_list_pages`] can walk any of them.
+pub(crate) trait PagedList: Sized {
+    /// The element type collected across pages.
+    type Item;
+
+    /// Total number of items across all pages, as reported by the API.
+    fn hit_count(&self) -> u64;
+
+    /// Consume the page and yield its items.
+    fn into_items(self) -> Vec<Self::Item>;
+}
+
+impl EuropePmcClient {
+    /// Fetch one page of a `/{source}/{id}/{segment}` list endpoint.
+    pub(crate) async fn get_list_page<T>(
+        &self,
+        id: &EuropePmcId,
+        segment: &str,
+        page: u32,
+        page_size: u32,
+        parse: fn(&str) -> ParseResult<T>,
+    ) -> Result<T> {
+        let endpoint = format!("{}/{}/{}", id.source, id.id, segment);
+        let page = page.to_string();
+        let page_size = page_size.to_string();
+        let response = self
+            .executor()
+            .get_endpoint(
+                &self.base_url,
+                &endpoint,
+                &[
+                    ("format", "json"),
+                    ("page", page.as_str()),
+                    ("pageSize", page_size.as_str()),
+                ],
+            )
+            .await?;
+        let text = response.text().await?;
+        Ok(parse(&text)?)
+    }
+
+    /// Walk a list endpoint from page 1 until it is exhausted.
+    ///
+    /// Stops on a short page (fewer items than [`DEFAULT_PAGE_SIZE`]) or once
+    /// the reported `hitCount` has been collected, so a server that keeps
+    /// returning full pages past its own total cannot loop forever.
+    pub(crate) async fn collect_list_pages<T: PagedList>(
+        &self,
+        id: &EuropePmcId,
+        segment: &str,
+        parse: fn(&str) -> ParseResult<T>,
+    ) -> Result<Vec<T::Item>> {
+        let mut collected = Vec::new();
+        let mut page = 1;
+        loop {
+            let list = self
+                .get_list_page(id, segment, page, DEFAULT_PAGE_SIZE, parse)
+                .await?;
+            let hit_count = list.hit_count();
+            let items = list.into_items();
+            let count = items.len();
+            collected.extend(items);
+            if count < DEFAULT_PAGE_SIZE as usize || collected.len() as u64 >= hit_count {
+                break;
+            }
+            page += 1;
+        }
+        Ok(collected)
+    }
+}

--- a/pubmed-client/src/europe_pmc/references.rs
+++ b/pubmed-client/src/europe_pmc/references.rs
@@ -10,9 +10,22 @@ use crate::error::Result;
 
 use super::client::EuropePmcClient;
 use super::id::EuropePmcId;
+use super::paged::PagedList;
 
-/// Default page size for reference/citation pagination.
-pub(crate) const DEFAULT_PAGE_SIZE: u32 = 100;
+/// Path segment of the `references` list endpoint.
+const SEGMENT: &str = "references";
+
+impl PagedList for EuropePmcReferenceList {
+    type Item = EuropePmcReference;
+
+    fn hit_count(&self) -> u64 {
+        self.hit_count
+    }
+
+    fn into_items(self) -> Vec<Self::Item> {
+        self.references
+    }
+}
 
 impl EuropePmcClient {
     /// Fetch a single page of the reference list (works cited) for a record.
@@ -23,41 +36,14 @@ impl EuropePmcClient {
         page: u32,
         page_size: u32,
     ) -> Result<EuropePmcReferenceList> {
-        let endpoint = format!("{}/{}/references", id.source, id.id);
-        let page = page.to_string();
-        let page_size = page_size.to_string();
-        let response = self
-            .executor()
-            .get_endpoint(
-                &self.base_url,
-                &endpoint,
-                &[
-                    ("format", "json"),
-                    ("page", page.as_str()),
-                    ("pageSize", page_size.as_str()),
-                ],
-            )
-            .await?;
-        let text = response.text().await?;
-        Ok(parse_references_response(&text)?)
+        self.get_list_page(id, SEGMENT, page, page_size, parse_references_response)
+            .await
     }
 
     /// Fetch all references for a record, following page numbers until exhausted.
     #[instrument(skip(self), fields(id = %id))]
     pub async fn get_references(&self, id: &EuropePmcId) -> Result<Vec<EuropePmcReference>> {
-        let mut collected = Vec::new();
-        let mut page = 1;
-        loop {
-            let list = self
-                .get_references_page(id, page, DEFAULT_PAGE_SIZE)
-                .await?;
-            let count = list.references.len();
-            collected.extend(list.references);
-            if count < DEFAULT_PAGE_SIZE as usize || collected.len() as u64 >= list.hit_count {
-                break;
-            }
-            page += 1;
-        }
-        Ok(collected)
+        self.collect_list_pages(id, SEGMENT, parse_references_response)
+            .await
     }
 }


### PR DESCRIPTION
Acts on the highest-priority findings from the agent-lens sweep in #254. Closes #250, closes #253, closes #211.

The two large parser splits (#205 `metadata.rs`, #249 `section.rs`) are deliberately **not** here — they are ~3000 lines of mechanical function movement and deserve their own reviewable PRs.

## 1. Europe PMC pagination (#250)

`references`, `citations` and `databaseLinks` are the same endpoint shape — `/{source}/{id}/{segment}?format=json&page=N&pageSize=M` — and each carried its own copy of the request *and* the page-walking loop (94% / 92% similar by `agent-lens analyze similarity`). The termination condition was written out three times, so a pagination bug needed three fixes.

New `europe_pmc/paged.rs` holds a `PagedList` trait (`hit_count` + `into_items`) and two helpers on `EuropePmcClient`:

```rust
async fn get_list_page<T>(&self, id, segment, page, page_size, parse: fn(&str) -> ParseResult<T>) -> Result<T>
async fn collect_list_pages<T: PagedList>(&self, id, segment, parse) -> Result<Vec<T::Item>>
```

All six public methods keep their signatures, doc comments and `#[instrument]` spans, and now delegate. Each endpoint module contributes only its path segment, its response type and one `impl PagedList`. `DEFAULT_PAGE_SIZE` also moves out of `references.rs`, which `citations.rs` and `links.rs` were importing from a sibling endpoint module.

`search.rs` uses cursorMark pagination, not page numbers, and is left alone.

**Honest result:** the duplicated *logic* is gone (the `get_citations` / `get_references` / `get_database_links` cluster no longer appears at all), but `similarity` still reports the three `*_page` methods at 92%. They are now three-line delegations that differ only in segment and parse function — that residue is the public API surface itself, and collapsing it further would mean generating the methods by macro, which costs more in readability and rustdoc than it saves. Left as is.

## 2. Cache backend tests (#253)

`SqliteCache`, `RedisCache` and `create_cache` had **no test at all**. The entire cache test surface was two `MemoryCache` unit tests plus six mocked `PmcClient` tests, all running on the default memory backend — so a backend that silently failed to persist, or a `create_cache` arm wired to the wrong variant, shipped green.

Added 11 tests:

| area | covered |
| --- | --- |
| SQLite | round-trip, `INSERT OR REPLACE`, TTL expiry, `clear`/`entry_count`, persistence across instances |
| `create_cache` | memory arm, SQLite arm actually builds a `SqliteCache` (asserted via the `cache` table it creates), and both fallback-to-memory arms |
| Redis | URL validation (no server needed), degrade-to-miss against an unreachable server, and an `#[ignore]`d round-trip behind `REDIS_URL` |

The TTL test uses `Duration::ZERO` rather than sleeping: `expires_at` lands on the current second and the read predicate is `expires_at > now`, so the entry is stale on insert — deterministic and instant.

**CI gap this also closes:** the default feature set does not compile these backends, so only the coverage job (`--all-features`) ever reached them. Added a `test:rs:cache-backends` mise task and a step in the Test Suite job.

## 3. Documentation (#211)

**CLAUDE.md** — the Europe PMC client (852 LOC, 9 modules in `pubmed-client`, 7 more in `pubmed-parser`) was entirely absent from both module trees and from Key Types. Also added: `request.rs` (the shared `RequestExecutor`), `tls.rs`, `pmc/common.rs`, `pmc/extracted.rs`, `pmc/parser/reader_utils.rs`, and the `pubmed-test-utils` crate. Corrected the formatter tree (`pmc/markdown.rs` has been a directory for a while) and replaced the `PmcFullText` key type — which no longer exists anywhere in the workspace — with `PmcArticle`.

**`.claude/skills/code-health/SKILL.md`** — this is agent-facing guidance, so stale paths in it get acted on. It named `pubmed-client/src/pmc/tar.rs` as "the #1 hotspot"; that file no longer exists. It listed `format_first_pub_date` and `format_author_name` as live duplicates; both were fixed some time ago. Re-pointed at the current epicentre, rewrote the findings to describe metric *shapes* rather than hard-coded scores so it ages better, added the analyzers that earned their keep in this sweep (`visibility`, `untested`, `hubs`, `cycles`, `delegation`, `risk`), and documented `agent-lens baseline`. The by-design/noise section was accurate and is kept.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt` / `dprint fmt` / `actionlint` — clean
- `RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo doc --all-features --no-deps` — clean
- `cargo test -p pubmed-client --features cache-sqlite,cache-redis --lib cache::` — 13 passed, 1 ignored (Redis round-trip)
- `cargo nextest run -p pubmed-client --test mocked_europe_pmc` — 7 passed, no test edits
- `cargo test --doc` (client/parser/formatter) — passed
- `cargo nextest run --workspace --no-fail-fast` — 677/704 passed. The 27 failures are pre-existing and unrelated: this container has unfetched Git LFS pointers under `test_data/`, and the identical 27 fail on a clean `main` checkout here (676/703). CI checks out with `lfs: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJej1b3n1igpWnesKL4QCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJej1b3n1igpWnesKL4QCZ)_