### PR TITLE
chore: unblock dependency upgrades across all ecosystems

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -5,6 +5,7 @@
   "yaml": {},
   "excludes": [
     "**/*-lock.json",
+    "**/pnpm-lock.yaml",
     "**/test_data/**",
     "tmp_*/**",
     "specs/**"

--- a/pubmed-client-py/examples/02_fetch_pmc_fulltext.py
+++ b/pubmed-client-py/examples/02_fetch_pmc_fulltext.py
@@ -50,7 +50,7 @@ def display_pmc_article(article: pubmed_client.PmcFullText) -> None:
     sections = article.sections()
     print(f"\nArticle Sections ({len(sections)}):")
     for i, section in enumerate(sections[:5], start=1):  # First 5 sections
-        section_title = section.title if section.title else f"Section {i}"
+        section_title = section.title or f"Section {i}"
         content_length = len(section.content)
         section_type = f" [{section.section_type}]" if section.section_type else ""
 
@@ -64,7 +64,7 @@ def display_pmc_article(article: pubmed_client.PmcFullText) -> None:
     print(f"\nFigures ({len(figures)}):")
     if figures:
         for i, figure in enumerate(figures[:3], start=1):  # First 3 figures
-            print(f"  {i}. {figure.label if figure.label else figure.id}")
+            print(f"  {i}. {figure.label or figure.id}")
             if figure.caption:
                 caption_preview = (
                     figure.caption[:100] + "..." if len(figure.caption) > 100 else figure.caption
@@ -80,7 +80,7 @@ def display_pmc_article(article: pubmed_client.PmcFullText) -> None:
     print(f"\nTables ({len(tables)}):")
     if tables:
         for i, table in enumerate(tables[:3], start=1):  # First 3 tables
-            print(f"  {i}. {table.label if table.label else table.id}")
+            print(f"  {i}. {table.label or table.id}")
         if len(tables) > 3:
             print(f"  ... and {len(tables) - 3} more tables")
     else:

--- a/pubmed-client-py/pyproject.toml
+++ b/pubmed-client-py/pyproject.toml
@@ -71,6 +71,7 @@ ignore = [
   # "T20", # flake8-print (https://pypi.org/project/flake8-print/)
   "ANN", # flkae8-annotations (https://pypi.org/project/flake8-annotations/)
   "INP001", # File {file} is part of an implicit namespace package. Add an `__init__.py`.
+  "CPY001", # Missing copyright notice at top of file (this project uses no file headers)
 
   # fmt confilict ignore
   # https://docs.astral.sh/ruff/formatter/#format-suppression

--- a/pubmed-client-wasm/tsconfig.json
+++ b/pubmed-client-wasm/tsconfig.json
@@ -21,7 +21,6 @@
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./tests/*"],
       "@/wasm/*": ["./tests/wasm/*"],

--- a/pubmed-parser/benches/pmc_parsing.rs
+++ b/pubmed-parser/benches/pmc_parsing.rs
@@ -1,7 +1,9 @@
 // Benchmark harness — unwrap/expect are fine here.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/pubmed-parser/benches/pubmed_parsing.rs
+++ b/pubmed-parser/benches/pubmed_parsing.rs
@@ -1,7 +1,9 @@
 // Benchmark harness — unwrap/expect are fine here.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -8,7 +8,6 @@
     "moduleResolution": "bundler",
     "module": "esnext",
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@site/*": ["./*"]
     },


### PR DESCRIPTION
Dependabot PRs across every ecosystem were failing on issues that belong to the repo rather than to any individual bump. This fixes them once so the upgrades can land.

Each change is a no-op against the currently pinned versions — verified locally before pushing.

## Changes

**`dprint.json` — exclude `pnpm-lock.yaml`**

dprint formats YAML and only `**/*-lock.json` was excluded, so the checked-in `pnpm-lock.yaml` files are dprint-formatted. Every time Dependabot regenerates one, pnpm writes its own native formatting and `Lint and Format` fails. This blocked all nine npm PRs. Lockfiles are generated artifacts and shouldn't be hand-formatted.

**`pubmed-parser/benches/*.rs` — import `black_box` from `std::hint`**

criterion 0.8 deprecates `criterion::black_box`, and `mise r lint` runs `cargo clippy --workspace --all-targets -- -D warnings`, so the deprecation fails the build. `std::hint::black_box` has been stable since Rust 1.66, so this compiles identically against the current criterion 0.5. Blocks #242.

**`tsconfig.json` (wasm + website) — drop `baseUrl`**

TypeScript 7 removed `baseUrl` (`error TS5102`). Both configs already use `"./"`-relative `paths`, which resolve against the tsconfig's own directory, so module resolution is unchanged on TypeScript 5. Blocks #226 and #236.

**`pubmed-client-py` — ignore `CPY001`, rewrite three ternaries**

ruff 0.16 promoted `CPY001` (missing copyright notice) and `FURB110` from preview to stable. The config uses `select = ["ALL"]`, so 14 new errors appeared. This project carries no copyright headers anywhere, so `CPY001` is ignored; the three `FURB110` sites were `x if x else y`, rewritten as `x or y`. Blocks #230.

## Verification

Run locally against the **current** (un-bumped) dependency versions:

- `dprint check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `website`: `pnpm run typecheck` and `pnpm run check` — clean
- `pubmed-client-py`: `ruff check .` and `ruff format --check .` under the pinned ruff 0.14.1 — clean

And against the **upgraded** versions, to confirm each fix actually unblocks its PR:

- criterion 0.8.2 + rstest 0.26.1 + indicatif 0.18.6: `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace --all-features` passing
- TypeScript 7.0.2 on wasm: `tsc --noEmit` clears `TS5102`; `biome ci` and `vitest` pass (24 tests)
- pytest 9.1.1: 87 passed; mypy 2.3.1 `--strict`: clean; `mypy.stubtest`: clean; ruff 0.16.3: clean

Ten test targets fail locally because `test_data/` is unfetched Git LFS pointers and `git-lfs` isn't installed in this environment. The identical set fails on unmodified `main`, so it's environmental — CI checks out with `lfs: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd1dH4rinuPiqGXbazbQEW)_